### PR TITLE
Fix PyPI Builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
   push:
     tags:
       - 'v*.*.*rc*'  # for testing releases
+      - 'v*.*.*dev*'  # for testing releases
 
 jobs:
   test:  # Copied from pytest.yml
@@ -75,9 +76,15 @@ jobs:
       run: |
         python3 -m build
 
+    - name: find wheel
+      id: find
+      run: |
+        WHEEL_FILE=$(ls dist/*.whl)
+        echo "::set-output name=wheel::${WHEEL_FILE}"
+
     - name: install wheel
       run: |
-        python3 -m pip install dist/sorunlib*.whl
+        python3 -m pip install ${{ steps.find.outputs.wheel }}[tests]
 
     - name: Run unit tests
       working-directory: ./tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: install wheel
       run: |
-        python3 -m pip install dist/sorunlib*.whl[tests]
+        python3 -m pip install dist/sorunlib*.whl
 
     - name: Run unit tests
       working-directory: ./tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: install wheel
       run: |
-        python3 -m pip install dist/ocs*.whl[tests]
+        python3 -m pip install dist/sorunlib*.whl[tests]
 
     - name: Run unit tests
       working-directory: ./tests


### PR DESCRIPTION
The way I was installing the wheel with the testing dependencies wasn't working with the optional extra_requires argument. This fixes that by finding the `.whl` file in a step before trying the installation.