### PR TITLE
Setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,10 @@ setup(
     ],
     python_requires=">=3.7",
     install_requires=[
-        'ocs>=0.9.1',
+        'ocs==0.9.1',
     ],
     extras_require={
-        "tests": ["pytest>=7.0.1", "pytest-cov>=3.0.0"],
+        "tests": ["pytest>=7.0.0", "pytest-cov>=3.0.0"],
         "docs": ["sphinx==4.2.0", "sphinx_rtd_theme==1.0.0"],
     },
 )


### PR DESCRIPTION
Mainly to auto-bump ocs versions when releases are issued.