### PR TITLE
Improve client intialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# tmp files
+*.swp
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/sorunlib/util.py
+++ b/src/sorunlib/util.py
@@ -79,8 +79,8 @@ def create_clients(config=None, test_mode=False):
     else:
         smurf_agent_class = 'PysmurfController'
 
-    acu_id = _find_instances('ACUAgent', config)
-    smurf_ids = _find_instances(smurf_agent_class, config)
+    acu_id = _find_instances('ACUAgent', config=config)
+    smurf_ids = _find_instances(smurf_agent_class, config=config)
 
     acu_client = OCSClient(acu_id[0])
     smurf_clients = [OCSClient(x) for x in smurf_ids]

--- a/src/sorunlib/util.py
+++ b/src/sorunlib/util.py
@@ -74,6 +74,8 @@ def create_clients(config=None, test_mode=False):
                        'smurf': [smurf_client1, smurf_client2, smurf_client3]}
 
     """
+    clients = {}
+
     if test_mode:
         smurf_agent_class = 'SmurfFileEmulator'
     else:
@@ -82,9 +84,11 @@ def create_clients(config=None, test_mode=False):
     acu_id = _find_instances('ACUAgent', config=config)
     smurf_ids = _find_instances(smurf_agent_class, config=config)
 
-    acu_client = OCSClient(acu_id[0])
-    smurf_clients = [OCSClient(x) for x in smurf_ids]
+    if acu_id:
+        acu_client = OCSClient(acu_id[0])
+        clients['acu'] = acu_client
+    if smurf_ids:
+        smurf_clients = [OCSClient(x) for x in smurf_ids]
+        clients['smurf'] = smurf_clients
 
-    clients = {'acu': acu_client,
-               'smurf': smurf_clients}
     return clients


### PR DESCRIPTION
This PR does two things:
- Fix a bug in `create_clients()` in the call to `_find_instances`.
- Only tries to add the clients to the `CLIENTS` dict if they are present.