### PR TITLE
Implement commands enough for F2F demo

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,8 @@ ignore =
     F403,
     # Name may be undefined, or defined from star imports
     F405,
+    # line break before binary operator
+    W503,
 exclude =
     versioneer.py,
     src/sorunlib/_version.py,

--- a/src/sorunlib/_internal.py
+++ b/src/sorunlib/_internal.py
@@ -1,0 +1,22 @@
+"""Internal module for shared utilities within sorunlib.
+
+The usual caveats apply, these interfaces might change without notice.
+
+"""
+
+
+def check_response(response):
+    """Check that a response from OCS indicates successful task/process
+    completion.
+
+    Args:
+        response (ocs.ocs_client.OCSReply): Response from an OCS operation
+            call.
+
+    Raises:
+        RuntimeError: When task/process has not completed successfully.
+
+    """
+    if not response.session['success']:
+        error = 'Task failed to complete successfully.\n' + str(response)
+        raise RuntimeError(error)

--- a/src/sorunlib/_internal.py
+++ b/src/sorunlib/_internal.py
@@ -4,6 +4,8 @@ The usual caveats apply, these interfaces might change without notice.
 
 """
 
+import ocs
+
 
 def check_response(response):
     """Check that a response from OCS indicates successful task/process
@@ -14,9 +16,20 @@ def check_response(response):
             call.
 
     Raises:
-        RuntimeError: When task/process has not completed successfully.
+        RuntimeError: When Operation has not completed successfully (either on
+            initial request or after completion) or the response has timed out.
 
     """
+    op = response.session['op_name']
+
+    if response.status == ocs.ERROR:
+        error = f"Request for Operation {op} failed.\n" + str(response)
+        raise RuntimeError(error)
+    elif response.status == ocs.TIMEOUT:
+        error = f"Timeout reached waiting for {op} to complete." + str(
+            response)
+        raise RuntimeError(error)
+
     if not response.session['success']:
         error = 'Task failed to complete successfully.\n' + str(response)
         raise RuntimeError(error)

--- a/src/sorunlib/acu.py
+++ b/src/sorunlib/acu.py
@@ -10,4 +10,7 @@ def move_to(az, el, wait=None):
         wait (float): amount of time to wait for motion to end
 
     """
-    run.CLIENTS['acu'].go_to(az=az, el=el, wait=wait)
+    resp = run.CLIENTS['acu'].go_to(az=az, el=el, wait=wait)
+    if not resp.session['success']:
+        error = 'Task failed to complete successfully.\n' + str(resp)
+        raise RuntimeError(error)

--- a/src/sorunlib/acu.py
+++ b/src/sorunlib/acu.py
@@ -10,4 +10,4 @@ def move_to(az, el, wait=None):
         wait (float): amount of time to wait for motion to end
 
     """
-    run.CLIENTS['acu'].go_to(az, el, wait)
+    run.CLIENTS['acu'].go_to(az=az, el=el, wait=wait)

--- a/src/sorunlib/acu.py
+++ b/src/sorunlib/acu.py
@@ -1,4 +1,5 @@
 import sorunlib as run
+from sorunlib._internal import check_response
 
 
 def move_to(az, el, wait=None):
@@ -11,6 +12,4 @@ def move_to(az, el, wait=None):
 
     """
     resp = run.CLIENTS['acu'].go_to(az=az, el=el, wait=wait)
-    if not resp.session['success']:
-        error = 'Task failed to complete successfully.\n' + str(resp)
-        raise RuntimeError(error)
+    check_response(resp)

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -1,6 +1,5 @@
-import time
-
 import sorunlib as run
+from sorunlib._internal import check_response
 
 
 def scan(description, stop_time, throw):
@@ -37,18 +36,8 @@ def scan(description, stop_time, throw):
 
     # Stop motion
     run.CLIENTS['acu'].generate_scan.stop()
-
-    # Confirm motion stopped
-    running = True
-    last_position = None
-    while running:
-        resp = run.CLIENTS['acu'].monitor.status()
-        az = resp.session['data']['Corrected Azimuth']
-        el = resp.session['data']['Corrected Elevation']
-        if (az, el) == last_position:
-            break
-        last_position = (az, el)
-        time.sleep(1)
+    resp = run.CLIENTS['acu'].generate_scan.wait()
+    check_response(resp)
 
     # Stop SMuRF streams
     run.smurf.stream('off')

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -1,5 +1,54 @@
-# import sorunlib as run
+import time
+
+import sorunlib as run
 
 
-def scan():
-    pass
+def scan(description, stop_time, throw):
+    """Run a constant elevation scan, collecting detector data.
+
+    Args:
+        description (str): Description of the field/object being scanned.
+        stop_time (str): Time in ISO format to scan until, i.e.
+            "2022-06-21T15:58:00"
+        throw (float): Half the scan width in azimuth. The scan will be twice
+            the throw in width, centered on the current position at the start
+            of the scan.
+
+    """
+    # Enable SMuRF streams
+    run.smurf.stream('on')
+
+    # Grab current telescope position
+    resp = run.CLIENTS['acu'].monitor.status()
+    az = resp.session['data']['Corrected Azimuth']
+    el = resp.session['data']['Corrected Elevation']
+
+    # Start telescope motion
+    resp = run.CLIENTS['acu'].generate_scan.start(az_endpoint1=az - throw,
+                                                  az_endpoint2=az + throw,
+                                                  az_speed=2,
+                                                  acc=2.0,
+                                                  el_endpoint1=el,
+                                                  el_endpoint2=el,
+                                                  el_speed=0)
+
+    # Wait until stop time
+    run.commands.wait(stop_time)
+
+    # Stop motion
+    run.CLIENTS['acu'].generate_scan.stop()
+
+    # Confirm motion stopped
+    running = True
+    last_position = None
+    while running:
+        resp = run.CLIENTS['acu'].monitor.status()
+        az = resp.session['data']['Corrected Azimuth']
+        el = resp.session['data']['Corrected Elevation']
+        if (az, el) == last_position:
+            break
+        last_position = (az, el)
+        time.sleep(1)
+
+    # Stop SMuRF streams
+    run.smurf.stream('off')

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -2,6 +2,9 @@ import sorunlib as run
 from sorunlib._internal import check_response
 
 
+OP_TIMEOUT = 60
+
+
 def scan(description, stop_time, throw):
     """Run a constant elevation scan, collecting detector data.
 
@@ -36,7 +39,7 @@ def scan(description, stop_time, throw):
 
     # Stop motion
     run.CLIENTS['acu'].generate_scan.stop()
-    resp = run.CLIENTS['acu'].generate_scan.wait()
+    resp = run.CLIENTS['acu'].generate_scan.wait(timeout=OP_TIMEOUT)
     check_response(resp)
 
     # Stop SMuRF streams

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -5,16 +5,15 @@ from sorunlib._internal import check_response
 OP_TIMEOUT = 60
 
 
-def scan(description, stop_time, throw):
+def scan(description, stop_time, width):
     """Run a constant elevation scan, collecting detector data.
 
     Args:
         description (str): Description of the field/object being scanned.
         stop_time (str): Time in ISO format to scan until, i.e.
             "2022-06-21T15:58:00"
-        throw (float): Half the scan width in azimuth. The scan will be twice
-            the throw in width, centered on the current position at the start
-            of the scan.
+        width (float): Scan width in azimuth. The scan will start at the
+            current position and move in the positive azimuth direction.
 
     """
     # Enable SMuRF streams
@@ -26,8 +25,8 @@ def scan(description, stop_time, throw):
     el = resp.session['data']['Corrected Elevation']
 
     # Start telescope motion
-    resp = run.CLIENTS['acu'].generate_scan.start(az_endpoint1=az - throw,
-                                                  az_endpoint2=az + throw,
+    resp = run.CLIENTS['acu'].generate_scan.start(az_endpoint1=az,
+                                                  az_endpoint2=az + width,
                                                   az_speed=2,
                                                   acc=2.0,
                                                   el_endpoint1=el,

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -3,7 +3,7 @@ from sorunlib._internal import check_response
 
 
 def bias_step():
-    """Perform a bias step on all SMuRF Controllers"""
+    """Perform a bias step on all SMuRF Controllers."""
     for smurf in run.CLIENTS['smurf']:
         smurf.take_bias_steps.start()
 
@@ -13,7 +13,7 @@ def bias_step():
 
 
 def iv_curve():
-    """Perform an iv curve on all SMuRF Controllers"""
+    """Perform an iv curve on all SMuRF Controllers."""
     for smurf in run.CLIENTS['smurf']:
         smurf.take_iv.start()
 
@@ -22,29 +22,65 @@ def iv_curve():
         check_response(resp)
 
 
-def tune_dets(test_mode=False):
-    """Perform detector tuning on all SMuRF Controllers.
+def uxm_setup(test_mode=False):
+    """Perform first-time setup procedure for a UXM.
 
     Args:
-        test_mode (bool): Run tune_dets() task in test_mode, removing emulated
+        test_mode (bool): Run uxm_setup() task in test_mode, removing emulated
             wait times.
 
     """
     for smurf in run.CLIENTS['smurf']:
-        smurf.tune_dets.start(test_mode=test_mode)
+        smurf.uxm_setup.start(test_mode=test_mode)
 
     for smurf in run.CLIENTS['smurf']:
-        resp = smurf.tune_dets.wait()
+        resp = smurf.uxm_setup.wait()
+        check_response(resp)
+
+
+def uxm_relock(test_mode=False):
+    """Relocks detectors to existing tune if setup has already been run.
+
+    Args:
+        test_mode (bool): Run uxm_setup() task in test_mode, removing emulated
+            wait times.
+
+    """
+    for smurf in run.CLIENTS['smurf']:
+        smurf.uxm_relock.start(test_mode=test_mode)
+
+    for smurf in run.CLIENTS['smurf']:
+        resp = smurf.uxm_relock.wait()
         check_response(resp)
 
 
 def bias_dets():
-    """Bias the detectors on all SMuRF Controllers"""
+    """Bias the detectors on all SMuRF Controllers."""
     for smurf in run.CLIENTS['smurf']:
         smurf.bias_dets.start()
 
     for smurf in run.CLIENTS['smurf']:
         resp = smurf.bias_dets.wait()
+        check_response(resp)
+
+
+def take_bgmap():
+    """Take a bgmap on all SMuRF Controllers."""
+    for smurf in run.CLIENTS['smurf']:
+        smurf.take_bgmap.start()
+
+    for smurf in run.CLIENTS['smurf']:
+        resp = smurf.take_bgmap.wait()
+        check_response(resp)
+
+
+def take_noise():
+    """Measure noise statistics from a short, 30 second, timestream."""
+    for smurf in run.CLIENTS['smurf']:
+        smurf.take_noise.start()
+
+    for smurf in run.CLIENTS['smurf']:
+        resp = smurf.take_noise.wait()
         check_response(resp)
 
 

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -1,4 +1,5 @@
 import sorunlib as run
+from sorunlib._internal import check_response
 
 
 def bias_step():
@@ -7,7 +8,8 @@ def bias_step():
         smurf.take_bias_steps.start()
 
     for smurf in run.CLIENTS['smurf']:
-        smurf.take_bias_steps.wait()
+        resp = smurf.take_bias_steps.wait()
+        check_response(resp)
 
 
 def iv_curve():
@@ -16,7 +18,8 @@ def iv_curve():
         smurf.take_iv.start()
 
     for smurf in run.CLIENTS['smurf']:
-        smurf.take_iv.wait()
+        resp = smurf.take_iv.wait()
+        check_response(resp)
 
 
 def tune_dets(test_mode=False):
@@ -31,7 +34,8 @@ def tune_dets(test_mode=False):
         smurf.tune_dets.start(test_mode=test_mode)
 
     for smurf in run.CLIENTS['smurf']:
-        smurf.tune_dets.wait()
+        resp = smurf.tune_dets.wait()
+        check_response(resp)
 
 
 def bias_dets():
@@ -40,7 +44,8 @@ def bias_dets():
         smurf.bias_dets.start()
 
     for smurf in run.CLIENTS['smurf']:
-        smurf.bias_dets.wait()
+        resp = smurf.bias_dets.wait()
+        check_response(resp)
 
 
 def stream(state):
@@ -59,6 +64,6 @@ def stream(state):
     else:
         for smurf in run.CLIENTS['smurf']:
             smurf.stream.stop()
-
-        for smurf in run.CLIENTS['smurf']:
-            print(smurf.stream.status())
+            resp = smurf.stream.wait()
+            check_response(resp)
+            print(resp)

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -4,16 +4,16 @@ import sorunlib as run
 def bias_step():
     """Perform a bias step on all SMuRF Controllers"""
     for smurf in run.CLIENTS['smurf']:
-        smurf.run.start('bias_step.sh')
+        smurf.take_bias_steps.start()
 
     for smurf in run.CLIENTS['smurf']:
-        smurf.run.wait()
+        smurf.take_bias_steps.wait()
 
 
 def iv_curve():
     """Perform a bias step on all SMuRF Controllers"""
     for smurf in run.CLIENTS['smurf']:
-        smurf.run.start('iv_curve.sh')
+        smurf.take_iv.start()
 
     for smurf in run.CLIENTS['smurf']:
-        smurf.run.wait()
+        smurf.take_iv.wait()

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -43,10 +43,22 @@ def bias_dets():
         smurf.bias_dets.wait()
 
 
-def stream():
-    """Stream data on all SMuRF Controllers"""
-    for smurf in run.CLIENTS['smurf']:
-        smurf.stream.start()
+def stream(state):
+    """Stream data on all SMuRF Controllers.
 
-    for smurf in run.CLIENTS['smurf']:
-        print(smurf.stream.status())
+    Args:
+        state (str): Streaming state, either 'on' or 'off'.
+
+    """
+    if state.lower() == 'on':
+        for smurf in run.CLIENTS['smurf']:
+            smurf.stream.start()
+
+        for smurf in run.CLIENTS['smurf']:
+            print(smurf.stream.status())
+    else:
+        for smurf in run.CLIENTS['smurf']:
+            smurf.stream.stop()
+
+        for smurf in run.CLIENTS['smurf']:
+            print(smurf.stream.status())

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -11,9 +11,42 @@ def bias_step():
 
 
 def iv_curve():
-    """Perform a bias step on all SMuRF Controllers"""
+    """Perform an iv curve on all SMuRF Controllers"""
     for smurf in run.CLIENTS['smurf']:
         smurf.take_iv.start()
 
     for smurf in run.CLIENTS['smurf']:
         smurf.take_iv.wait()
+
+
+def tune_dets(test_mode=False):
+    """Perform detector tuning on all SMuRF Controllers.
+
+    Args:
+        test_mode (bool): Run tune_dets() task in test_mode, removing emulated
+            wait times.
+
+    """
+    for smurf in run.CLIENTS['smurf']:
+        smurf.tune_dets.start(test_mode=test_mode)
+
+    for smurf in run.CLIENTS['smurf']:
+        smurf.tune_dets.wait()
+
+
+def bias_dets():
+    """Bias the detectors on all SMuRF Controllers"""
+    for smurf in run.CLIENTS['smurf']:
+        smurf.bias_dets.start()
+
+    for smurf in run.CLIENTS['smurf']:
+        smurf.bias_dets.wait()
+
+
+def stream():
+    """Stream data on all SMuRF Controllers"""
+    for smurf in run.CLIENTS['smurf']:
+        smurf.stream.start()
+
+    for smurf in run.CLIENTS['smurf']:
+        print(smurf.stream.status())

--- a/tests/integration/test_example_script.py
+++ b/tests/integration/test_example_script.py
@@ -23,5 +23,6 @@ def test_script():
     smurf.bias_step()
     # wait until 1 second in future
     wait((dt.datetime.now() + dt.timedelta(seconds=1)).isoformat())
-    seq.scan()
+    seq.scan(description='test', stop_time=(dt.datetime.now()
+             + dt.timedelta(seconds=1)).isoformat(), throw=10.)
     smurf.bias_step()

--- a/tests/integration/test_example_script.py
+++ b/tests/integration/test_example_script.py
@@ -24,5 +24,5 @@ def test_script():
     # wait until 1 second in future
     wait((dt.datetime.now() + dt.timedelta(seconds=1)).isoformat())
     seq.scan(description='test', stop_time=(dt.datetime.now()
-             + dt.timedelta(seconds=1)).isoformat(), throw=10.)
+             + dt.timedelta(seconds=1)).isoformat(), width=20.)
     smurf.bias_step()

--- a/tests/test__internal.py
+++ b/tests/test__internal.py
@@ -1,0 +1,43 @@
+import os
+import ocs
+import pytest
+
+from unittest.mock import MagicMock
+from ocs.ocs_agent import OpSession
+from ocs.ocs_client import OCSReply
+
+from sorunlib._internal import check_response
+
+os.environ["OCS_CONFIG_DIR"] = "./test_util/"
+
+
+def create_session(op_name, success=None):
+    """Create an OpSession with a mocked app for testing."""
+    mock_app = MagicMock()
+    session = OpSession(1, op_name, app=mock_app)
+    session.op_name = 'test_op'
+    session.success = success
+
+    return session.encoded()
+
+
+invalid_responses = [(OCSReply(ocs.TIMEOUT,
+                               'msg',
+                               create_session('test', success=True))),
+                     (OCSReply(ocs.ERROR,
+                               'msg',
+                               create_session('test')))]
+
+valid_responses = [
+    (OCSReply(ocs.OK, 'msg', create_session('test', success=True)))]
+
+
+@pytest.mark.parametrize("response", invalid_responses)
+def test_check_response_raises(response):
+    with pytest.raises(RuntimeError):
+        check_response(response)
+
+
+@pytest.mark.parametrize("response", valid_responses)
+def test_check_response(response):
+    check_response(response)

--- a/tests/test_acu.py
+++ b/tests/test_acu.py
@@ -18,7 +18,7 @@ def mocked_clients(test_mode):
 
 @patch('sorunlib.create_clients', mocked_clients)
 def test_move_to():
-    acu.run.initialize()
+    acu.run.initialize(test_mode=True)
     acu.move_to(180, 60)
     acu.run.CLIENTS['acu'].go_to.assert_called_with(az=180, el=60, wait=None)
 

--- a/tests/test_acu.py
+++ b/tests/test_acu.py
@@ -1,8 +1,11 @@
 import os
 os.environ["OCS_CONFIG_DIR"] = "./test_util/"
 
+import pytest
+
 from unittest.mock import MagicMock, patch
 
+from ocs.ocs_client import OCSReply
 from sorunlib import acu
 
 
@@ -18,3 +21,12 @@ def test_move_to():
     acu.run.initialize()
     acu.move_to(180, 60)
     acu.run.CLIENTS['acu'].go_to.assert_called_with(az=180, el=60, wait=None)
+
+
+@patch('sorunlib.create_clients', mocked_clients)
+def test_move_to_failed():
+    acu.run.initialize()
+    mocked_response = OCSReply(0, 'msg', {'success': False})
+    acu.run.CLIENTS['acu'].go_to.side_effect = [mocked_response]
+    with pytest.raises(RuntimeError):
+        acu.move_to(180, 90)

--- a/tests/test_acu.py
+++ b/tests/test_acu.py
@@ -17,4 +17,4 @@ def mocked_clients(test_mode):
 def test_move_to():
     acu.run.initialize()
     acu.move_to(180, 60)
-    acu.run.CLIENTS['acu'].go_to.assert_called_with(180, 60, None)
+    acu.run.CLIENTS['acu'].go_to.assert_called_with(az=180, el=60, wait=None)

--- a/tests/test_acu.py
+++ b/tests/test_acu.py
@@ -26,7 +26,8 @@ def test_move_to():
 @patch('sorunlib.create_clients', mocked_clients)
 def test_move_to_failed():
     acu.run.initialize()
-    mocked_response = OCSReply(0, 'msg', {'success': False})
+    mocked_response = OCSReply(
+        0, 'msg', {'success': False, 'op_name': 'go_to'})
     acu.run.CLIENTS['acu'].go_to.side_effect = [mocked_response]
     with pytest.raises(RuntimeError):
         acu.move_to(180, 90)

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -15,5 +15,5 @@ def mocked_clients():
 
 @patch('sorunlib.create_clients', mocked_clients)
 def test_scan():
-    # seq.run.initialize()
+    # seq.run.initialize(test_mode = True)
     seq.scan()

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -1,12 +1,13 @@
 import os
 os.environ["OCS_CONFIG_DIR"] = "./test_util/"
+import datetime as dt
 
 from unittest.mock import MagicMock, patch
 
 from sorunlib import seq
 
 
-def mocked_clients():
+def mocked_clients(test_mode):
     clients = {'acu': MagicMock(),
                'smurf': [MagicMock(), MagicMock(), MagicMock()]}
 
@@ -14,6 +15,8 @@ def mocked_clients():
 
 
 @patch('sorunlib.create_clients', mocked_clients)
+@patch('sorunlib.commands.time.sleep', MagicMock())
 def test_scan():
-    # seq.run.initialize(test_mode = True)
-    seq.scan()
+    seq.run.initialize(test_mode=True)
+    target = dt.datetime.now() + dt.timedelta(seconds=1)
+    seq.scan(description='test', stop_time=target.isoformat(), throw=10.)

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -19,4 +19,4 @@ def mocked_clients(test_mode):
 def test_scan():
     seq.run.initialize(test_mode=True)
     target = dt.datetime.now() + dt.timedelta(seconds=1)
-    seq.scan(description='test', stop_time=target.isoformat(), throw=10.)
+    seq.scan(description='test', stop_time=target.isoformat(), width=20.)

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -27,3 +27,27 @@ def test_iv_curve():
     smurf.iv_curve()
     for client in smurf.run.CLIENTS['smurf']:
         client.take_iv.start.assert_called_once()
+
+
+@patch('sorunlib.create_clients', mocked_clients)
+def test_tune_dets():
+    smurf.run.initialize(test_mode=True)
+    smurf.tune_dets(test_mode=True)
+    for client in smurf.run.CLIENTS['smurf']:
+        client.tune_dets.start.assert_called_once()
+
+
+@patch('sorunlib.create_clients', mocked_clients)
+def test_bias_dets():
+    smurf.run.initialize(test_mode=True)
+    smurf.bias_dets()
+    for client in smurf.run.CLIENTS['smurf']:
+        client.bias_dets.start.assert_called_once()
+
+
+@patch('sorunlib.create_clients', mocked_clients)
+def test_stream():
+    smurf.run.initialize(test_mode=True)
+    smurf.stream()
+    for client in smurf.run.CLIENTS['smurf']:
+        client.stream.start.assert_called_once()

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -30,11 +30,19 @@ def test_iv_curve():
 
 
 @patch('sorunlib.create_clients', mocked_clients)
-def test_tune_dets():
+def test_uxm_setup():
     smurf.run.initialize(test_mode=True)
-    smurf.tune_dets(test_mode=True)
+    smurf.uxm_setup(test_mode=True)
     for client in smurf.run.CLIENTS['smurf']:
-        client.tune_dets.start.assert_called_once()
+        client.uxm_setup.start.assert_called_once()
+
+
+@patch('sorunlib.create_clients', mocked_clients)
+def test_uxm_relock():
+    smurf.run.initialize(test_mode=True)
+    smurf.uxm_relock(test_mode=True)
+    for client in smurf.run.CLIENTS['smurf']:
+        client.uxm_relock.start.assert_called_once()
 
 
 @patch('sorunlib.create_clients', mocked_clients)
@@ -43,6 +51,22 @@ def test_bias_dets():
     smurf.bias_dets()
     for client in smurf.run.CLIENTS['smurf']:
         client.bias_dets.start.assert_called_once()
+
+
+@patch('sorunlib.create_clients', mocked_clients)
+def test_bgmap():
+    smurf.run.initialize(test_mode=True)
+    smurf.take_bgmap()
+    for client in smurf.run.CLIENTS['smurf']:
+        client.take_bgmap.start.assert_called_once()
+
+
+@patch('sorunlib.create_clients', mocked_clients)
+def test_take_noise():
+    smurf.run.initialize(test_mode=True)
+    smurf.take_noise()
+    for client in smurf.run.CLIENTS['smurf']:
+        client.take_noise.start.assert_called_once()
 
 
 @patch('sorunlib.create_clients', mocked_clients)

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -48,6 +48,6 @@ def test_bias_dets():
 @patch('sorunlib.create_clients', mocked_clients)
 def test_stream():
     smurf.run.initialize(test_mode=True)
-    smurf.stream()
+    smurf.stream(state='on')
     for client in smurf.run.CLIENTS['smurf']:
         client.stream.start.assert_called_once()

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -15,7 +15,7 @@ def mocked_clients(test_mode):
 
 @patch('sorunlib.create_clients', mocked_clients)
 def test_bias_step():
-    smurf.run.initialize()
+    smurf.run.initialize(test_mode=True)
     smurf.bias_step()
     for client in smurf.run.CLIENTS['smurf']:
         client.run.start.assert_called_with('bias_step.sh')
@@ -24,7 +24,7 @@ def test_bias_step():
 
 @patch('sorunlib.create_clients', mocked_clients)
 def test_iv_curve():
-    smurf.run.initialize()
+    smurf.run.initialize(test_mode=True)
     smurf.iv_curve()
     for client in smurf.run.CLIENTS['smurf']:
         client.run.start.assert_called_with('iv_curve.sh')

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -18,8 +18,7 @@ def test_bias_step():
     smurf.run.initialize(test_mode=True)
     smurf.bias_step()
     for client in smurf.run.CLIENTS['smurf']:
-        client.run.start.assert_called_with('bias_step.sh')
-        client.run.start.assert_called_once()
+        client.take_bias_steps.start.assert_called_once()
 
 
 @patch('sorunlib.create_clients', mocked_clients)
@@ -27,5 +26,4 @@ def test_iv_curve():
     smurf.run.initialize(test_mode=True)
     smurf.iv_curve()
     for client in smurf.run.CLIENTS['smurf']:
-        client.run.start.assert_called_with('iv_curve.sh')
-        client.run.start.assert_called_once()
+        client.take_iv.start.assert_called_once()


### PR DESCRIPTION
This PR marks the state sorunlib was in for the F2F demo, plus some recent updates that follow the API changes to the SMuRF File Emulator agent.

It still doesn't include things like:
- disable_mce-like command
- database logging of commands run
- interrupt handling

Those will come in a later PR, I just want to get this first pass merged.