### PR TITLE
Scan registry for active agents to build client list from

### DIFF
--- a/src/sorunlib/util.py
+++ b/src/sorunlib/util.py
@@ -56,6 +56,34 @@ def _find_instances(agent_class, host=None, config=None):
     return instances
 
 
+def _find_active_instances(agent_class, config=None):
+    """Find all instances of an Agent Class currently online, based on the
+    Agents known by the registry.
+
+    Args:
+        agent_class (str): Agent Class name to search for, must match Agent
+            Class defined by an OCS Agent (and thus also defined in the SCF.)
+        config (str): Path to the OCS Site Config File. If None the default
+            file in OCS_CONFIG_DIR will be used.
+
+    Returns:
+        list: List of instance-id's matching the given agent_class.
+
+    """
+    cfg = _load_site_config(config)
+
+    reg_client = OCSClient(cfg.hub.data['registry_address'])
+    _, _, session = reg_client.main.status()
+
+    instances = []
+    for entry in session['data'].values():
+        if entry['agent_class'] == agent_class:
+            instance_id = entry['agent_address'].split('.')[-1]
+            instances.append(instance_id)
+
+    return instances
+
+
 def create_clients(config=None, test_mode=False):
     """Create all clients needed for commanding a single platform.
 
@@ -81,8 +109,8 @@ def create_clients(config=None, test_mode=False):
     else:
         smurf_agent_class = 'PysmurfController'
 
-    acu_id = _find_instances('ACUAgent', config=config)
-    smurf_ids = _find_instances(smurf_agent_class, config=config)
+    acu_id = _find_active_instances('ACUAgent', config=config)
+    smurf_ids = _find_active_instances(smurf_agent_class, config=config)
 
     if acu_id:
         acu_client = OCSClient(acu_id[0])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -50,7 +50,22 @@ def mock_registry_client(*args, **kwargs):
                                 'take_noise': 1,
                                 'stream': 1},
                             'agent_class': 'SmurfFileEmulator',
-                            'agent_address': 'observatory.smurf-file-emulator-7'}}}
+                            'agent_address': 'observatory.smurf-file-emulator-7'},
+                        'observatory.acu-sat1': {
+                            'expired': False,
+                            'time_expired': None,
+                            'last_updated': 1669997169.469505,
+                            'op_codes': {
+                                'monitor': 3,
+                                'broadcast': 3,
+                                'generate_scan': 1,
+                                'go_to': 1,
+                                'constant_velocity_scan': 1,
+                                'fromfile_scan': 1,
+                                'set_boresight': 1,
+                                'stop_and_clear': 1},
+                            'agent_class': 'ACUAgent',
+                            'agent_address': 'observatory.acu-sat1'}}}
     client.main.status = MagicMock(return_value=(None, None, session_dict))
     return client
 
@@ -79,17 +94,16 @@ def test_find_active_instances():
     assert 'smurf-file-emulator-7' in instances
 
 
-@patch('sorunlib.util.OCSClient', MagicMock())
+@patch('sorunlib.util.OCSClient', mock_registry_client)
 def test_create_clients():
     clients = util.create_clients()
     assert 'acu' in clients
-    assert 'smurf' in clients
-    assert len(clients['smurf']) == 1
+    assert 'smurf' not in clients  # since we're not in test_mode
 
 
-@patch('sorunlib.util.OCSClient', MagicMock())
+@patch('sorunlib.util.OCSClient', mock_registry_client)
 def test_create_clients_test_mode():
     clients = util.create_clients(test_mode=True)
     assert 'acu' in clients
     assert 'smurf' in clients
-    assert len(clients['smurf']) == 1
+    assert len(clients['smurf']) == 2

--- a/tests/test_util/default.yaml
+++ b/tests/test_util/default.yaml
@@ -3,6 +3,7 @@ hub:
   wamp_http: http://localhost:8001/call
   wamp_realm: test_realm
   address_root: observatory
+  registry_address: observatory.registry
 
 hosts:
     localhost: {


### PR DESCRIPTION
This PR replaces use of `_find_instances()`, which returned the instance-id's corresponding to a given agent-class only based upon the ocs site config file. Instead we now have `_find_active_instances()`, which also returns instance-id's, but now based on which Agents are online on the network as reported by the registry's main process' `session.data`.

Testing this requires mocking the response from the registry, which we do now when testing building the client list. The hardcoded registry response is based on the active end to end testing system.

For some context, this solves the issue that on live systems the pysmurf-controller agents are split across multiple nodes (and thus the configs are split). `_find_instances()` wouldn't catch these distributed agents unless all hosts were defined in the local SCF.