### PR TITLE
Create way to limit commanded pysmurf-controllers

### DIFF
--- a/docs/design.rst
+++ b/docs/design.rst
@@ -42,6 +42,7 @@ An example script in sorunlib looks like:
     from sorunlib import *
 
     initialize()
+    smurf.set_targets(['smurf1'])
 
     wait("2022-02-16 18:00:00")
     acu.move_to(39.39, 64.27)
@@ -55,6 +56,10 @@ An example script in sorunlib looks like:
 For comparison a similar ACT schedule looks like:
 
 .. code-block::
+
+    enable_mces
+    disable_mce2
+    disable_mce3
 
     {soft_wait,{until,{2022,03,10},{20,00,00},utc}}
     {move_to,39.39,64.27}

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -2,6 +2,26 @@ import sorunlib as run
 from sorunlib._internal import check_response
 
 
+def set_targets(targets):
+    """Set the target pysmurf-controller Agents that sorunlib will command.
+
+    Args:
+        targets (list): List of pysmurf-controller instance-ids to send future
+            commands to. This must be a subset of the currently active clients
+            list.
+
+    Notes:
+        This modifies the global ``sorunlib.CLIENTS`` list.
+
+    """
+    _smurf_clients = []
+    for smurf in run.CLIENTS['smurf']:
+        if smurf.instance_id in targets:
+            _smurf_clients.append(smurf)
+
+    run.CLIENTS['smurf'] = _smurf_clients
+
+
 def bias_step():
     """Perform a bias step on all SMuRF Controllers."""
     for smurf in run.CLIENTS['smurf']:

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -6,11 +6,29 @@ from unittest.mock import MagicMock, patch
 from sorunlib import smurf
 
 
+def _mock_smurf_client(instance_id):
+    smurf = MagicMock()
+    smurf.instance_id = instance_id
+
+    return smurf
+
+
 def mocked_clients(test_mode):
+    smurf_ids = ['smurf1', 'smurf2', 'smurf3']
+    smurfs = [_mock_smurf_client(id_) for id_ in smurf_ids]
+
     clients = {'acu': MagicMock(),
-               'smurf': [MagicMock(), MagicMock(), MagicMock()]}
+               'smurf': smurfs}
 
     return clients
+
+
+@patch('sorunlib.create_clients', mocked_clients)
+def test_set_targets():
+    smurf.run.initialize(test_mode=True)
+    smurf.set_targets(['smurf1'])
+    assert len(smurf.run.CLIENTS['smurf']) == 1
+    assert smurf.run.CLIENTS['smurf'][0].instance_id == 'smurf1'
 
 
 @patch('sorunlib.create_clients', mocked_clients)


### PR DESCRIPTION
sorunlib currently will build a list of all pysmurf-controller agents, initialize clients for them, and command them all. This PR introduces `smurf.set_targets()`, which takes a list of pysmurf-controller instance-ids and limits the active clients to only those in the provided list.

This allows setting up the start of the sorunlib script to run on only a subset (or even single) pysmurf-controller via:

```
from sorunlib import *
initialize()
smurf.set_targets(['smurf1'])
```

Future `smurf.*` commands will only control 'smurf1'.