### PR TITLE
Add skipped pytest workflow

### DIFF
--- a/.github/workflows/skipped-pytest.yml
+++ b/.github/workflows/skipped-pytest.yml
@@ -1,0 +1,18 @@
+name: Run Tests
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '**.rst'
+      - '**.md'
+      - '.flake8'
+      - '.pre-commit-config.yaml'
+
+jobs:
+  test:
+    name: pytest with coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: 'echo "No build required" '


### PR DESCRIPTION
Allows required checks to pass even if we skip running pytest due to only non-tested files being changed.