### PR TITLE
Relax docs dependency version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     ],
     extras_require={
         "tests": ["pytest>=7.0.0", "pytest-cov>=3.0.0"],
-        "docs": ["sphinx==5.3.0", "sphinx_rtd_theme==1.1.1"],
+        "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=1.1.1"],
     },
 )


### PR DESCRIPTION
I used to think this was better for running on readthedocs, but I'm not convinced anymore. Relaxing these requirements will also reduce the amount of dependabot updates.