### PR TITLE
Fix issues identified in first automated schedule runs

### DIFF
--- a/src/sorunlib/acu.py
+++ b/src/sorunlib/acu.py
@@ -2,14 +2,13 @@ import sorunlib as run
 from sorunlib._internal import check_response
 
 
-def move_to(az, el, wait=None):
+def move_to(az, el):
     """Move telescope to specified coordinates.
 
     Args:
         az (float): destination angle for the azimuthal axis
         el (float): destination angle for the elevation axis
-        wait (float): amount of time to wait for motion to end
 
     """
-    resp = run.CLIENTS['acu'].go_to(az=az, el=el, wait=wait)
+    resp = run.CLIENTS['acu'].go_to(az=az, el=el)
     check_response(resp)

--- a/src/sorunlib/commands.py
+++ b/src/sorunlib/commands.py
@@ -6,15 +6,22 @@ def wait(target_time):
     """Wait until a specified time.
 
     Args:
-        target_time (str): Time in ISO format to wait until,
-            i.e. "2015-10-21T07:28:00"
+        target_time (str): Time in ISO format and in UTC timezone to wait
+            until, i.e. "2015-10-21T07:28:00", "2023-01-01T0:00:00+00:00"
 
     """
-    t0 = dt.datetime.now()
-    t1 = dt.datetime.fromisoformat(target_time)
+    target = dt.datetime.fromisoformat(target_time)
+    TZ = target.tzinfo
 
-    assert t1 > t0, f"time {t1} is in the past"
+    if TZ not in [None, dt.timezone.utc]:
+        offset = target.tzinfo.tzname(None)
+        raise ValueError(f'Unsupported timezone ({offset}) detected. '
+                         + 'Timezone must be UTC.')
 
-    diff = t1 - t0
+    now = dt.datetime.now(TZ)
+
+    assert target > now, f"time {target} is in the past"
+
+    diff = target - now
     print(f"Waiting for {diff.total_seconds()} seconds")
     time.sleep(diff.total_seconds())

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -21,14 +21,14 @@ def scan(description, stop_time, width):
 
     # Grab current telescope position
     resp = run.CLIENTS['acu'].monitor.status()
-    az = resp.session['data']['Corrected Azimuth']
-    el = resp.session['data']['Corrected Elevation']
+    az = resp.session['data']['StatusDetailed']['Corrected Azimuth']
+    el = resp.session['data']['StatusDetailed']['Corrected Elevation']
 
     # Start telescope motion
     resp = run.CLIENTS['acu'].generate_scan.start(az_endpoint1=az,
                                                   az_endpoint2=az + width,
                                                   az_speed=2,
-                                                  acc=2.0,
+                                                  az_accel=2.0,
                                                   el_endpoint1=el,
                                                   el_endpoint2=el,
                                                   el_speed=0)

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -33,6 +33,9 @@ def scan(description, stop_time, width):
                                                   el_endpoint2=el,
                                                   el_speed=0)
 
+    if not resp.session:
+        raise Exception(f"Generate Scan failed to start:\n  {resp}")
+
     # Wait until stop time
     run.commands.wait(stop_time)
 

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -19,30 +19,31 @@ def scan(description, stop_time, width):
     # Enable SMuRF streams
     run.smurf.stream('on')
 
-    # Grab current telescope position
-    resp = run.CLIENTS['acu'].monitor.status()
-    az = resp.session['data']['StatusDetailed']['Corrected Azimuth']
-    el = resp.session['data']['StatusDetailed']['Corrected Elevation']
+    try:
+        # Grab current telescope position
+        resp = run.CLIENTS['acu'].monitor.status()
+        az = resp.session['data']['StatusDetailed']['Corrected Azimuth']
+        el = resp.session['data']['StatusDetailed']['Corrected Elevation']
 
-    # Start telescope motion
-    resp = run.CLIENTS['acu'].generate_scan.start(az_endpoint1=az,
-                                                  az_endpoint2=az + width,
-                                                  az_speed=2,
-                                                  az_accel=2.0,
-                                                  el_endpoint1=el,
-                                                  el_endpoint2=el,
-                                                  el_speed=0)
+        # Start telescope motion
+        resp = run.CLIENTS['acu'].generate_scan.start(az_endpoint1=az,
+                                                      az_endpoint2=az + width,
+                                                      az_speed=2,
+                                                      az_accel=2.0,
+                                                      el_endpoint1=el,
+                                                      el_endpoint2=el,
+                                                      el_speed=0)
 
-    if not resp.session:
-        raise Exception(f"Generate Scan failed to start:\n  {resp}")
+        if not resp.session:
+            raise Exception(f"Generate Scan failed to start:\n  {resp}")
 
-    # Wait until stop time
-    run.commands.wait(stop_time)
+        # Wait until stop time
+        run.commands.wait(stop_time)
 
-    # Stop motion
-    run.CLIENTS['acu'].generate_scan.stop()
-    resp = run.CLIENTS['acu'].generate_scan.wait(timeout=OP_TIMEOUT)
-    check_response(resp)
-
-    # Stop SMuRF streams
-    run.smurf.stream('off')
+        # Stop motion
+        run.CLIENTS['acu'].generate_scan.stop()
+        resp = run.CLIENTS['acu'].generate_scan.wait(timeout=OP_TIMEOUT)
+        check_response(resp)
+    finally:
+        # Stop SMuRF streams
+        run.smurf.stream('off')

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -109,11 +109,8 @@ def stream(state):
         for smurf in run.CLIENTS['smurf']:
             smurf.stream.start()
 
-        for smurf in run.CLIENTS['smurf']:
-            print(smurf.stream.status())
     else:
         for smurf in run.CLIENTS['smurf']:
             smurf.stream.stop()
             resp = smurf.stream.wait()
             check_response(resp)
-            print(resp)

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -42,16 +42,10 @@ def iv_curve():
         check_response(resp)
 
 
-def uxm_setup(test_mode=False):
-    """Perform first-time setup procedure for a UXM.
-
-    Args:
-        test_mode (bool): Run uxm_setup() task in test_mode, removing emulated
-            wait times.
-
-    """
+def uxm_setup():
+    """Perform first-time setup procedure for a UXM."""
     for smurf in run.CLIENTS['smurf']:
-        smurf.uxm_setup.start(test_mode=test_mode)
+        smurf.uxm_setup.start()
 
     for smurf in run.CLIENTS['smurf']:
         resp = smurf.uxm_setup.wait()

--- a/src/sorunlib/util.py
+++ b/src/sorunlib/util.py
@@ -77,6 +77,9 @@ def _find_active_instances(agent_class, config=None):
 
     instances = []
     for entry in session['data'].values():
+        if entry['expired']:
+            continue
+
         if entry['agent_class'] == agent_class:
             instance_id = entry['agent_address'].split('.')[-1]
             instances.append(instance_id)

--- a/tests/test_acu.py
+++ b/tests/test_acu.py
@@ -20,7 +20,7 @@ def mocked_clients(test_mode):
 def test_move_to():
     acu.run.initialize(test_mode=True)
     acu.move_to(180, 60)
-    acu.run.CLIENTS['acu'].go_to.assert_called_with(az=180, el=60, wait=None)
+    acu.run.CLIENTS['acu'].go_to.assert_called_with(az=180, el=60)
 
 
 @patch('sorunlib.create_clients', mocked_clients)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,9 +8,17 @@ from unittest.mock import MagicMock, patch
 from sorunlib.commands import wait
 
 
-def test_wait_in_past():
+@pytest.mark.parametrize("target_time", ["2020-01-01T00:00:00", "2020-01-01T00:00:00+00:00"])
+def test_wait_in_past(target_time):
     with pytest.raises(AssertionError):
-        wait("2020-01-01T00:00:00")
+        wait(target_time)
+
+
+def test_wait_unsupported_tz():
+    with pytest.raises(ValueError):
+        tz = dt.timezone(offset=dt.timedelta(hours=5))
+        t = dt.datetime.now(tz).isoformat()  # i.e. '2023-04-22T00:59:56.264293+05:00'
+        wait(t)
 
 
 # patch out time.sleep so we don't actually wait during testing

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -2,8 +2,10 @@ import os
 os.environ["OCS_CONFIG_DIR"] = "./test_util/"
 import datetime as dt
 
+import pytest
 from unittest.mock import MagicMock, patch
 
+import sorunlib
 from sorunlib import seq
 
 
@@ -20,3 +22,18 @@ def test_scan():
     seq.run.initialize(test_mode=True)
     target = dt.datetime.now() + dt.timedelta(seconds=1)
     seq.scan(description='test', stop_time=target.isoformat(), width=20.)
+
+
+@patch('sorunlib.create_clients', mocked_clients)
+@patch('sorunlib.commands.time.sleep', MagicMock())
+def test_scan_failed_to_start():
+    seq.run.initialize(test_mode=True)
+
+    # Setup mock OCSReply without session object
+    mock_reply = MagicMock()
+    mock_reply.session = None
+    sorunlib.CLIENTS['acu'].generate_scan.start = MagicMock(return_value=mock_reply)
+
+    target = dt.datetime.now() + dt.timedelta(seconds=1)
+    with pytest.raises(Exception):
+        seq.scan(description='test', stop_time=target.isoformat(), width=20.)

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -50,7 +50,7 @@ def test_iv_curve():
 @patch('sorunlib.create_clients', mocked_clients)
 def test_uxm_setup():
     smurf.run.initialize(test_mode=True)
-    smurf.uxm_setup(test_mode=True)
+    smurf.uxm_setup()
     for client in smurf.run.CLIENTS['smurf']:
         client.uxm_setup.start.assert_called_once()
 
@@ -58,7 +58,7 @@ def test_uxm_setup():
 @patch('sorunlib.create_clients', mocked_clients)
 def test_uxm_relock():
     smurf.run.initialize(test_mode=True)
-    smurf.uxm_relock(test_mode=True)
+    smurf.uxm_relock()
     for client in smurf.run.CLIENTS['smurf']:
         client.uxm_relock.start.assert_called_once()
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -51,6 +51,17 @@ def mock_registry_client(*args, **kwargs):
                                 'stream': 1},
                             'agent_class': 'SmurfFileEmulator',
                             'agent_address': 'observatory.smurf-file-emulator-7'},
+                        'observatory.fake-data-1': {
+                            'expired': True,
+                            'time_expired': None,
+                            'last_updated': 1669935108.989246,
+                            'op_codes': {
+                                'acq': 3,
+                                'count': 3,
+                                'set_heartbeat': 1,
+                                'delay_task': 1},
+                            'agent_class': 'FakeDataAgent',
+                            'agent_address': 'observatory.fake-data-1'},
                         'observatory.acu-sat1': {
                             'expired': False,
                             'time_expired': None,
@@ -92,6 +103,12 @@ def test_find_active_instances():
     instances = util._find_active_instances('SmurfFileEmulator')
     assert 'smurf-file-emulator-5' in instances
     assert 'smurf-file-emulator-7' in instances
+
+
+@patch('sorunlib.util.OCSClient', mock_registry_client)
+def test_find_active_instances_expired():
+    instances = util._find_active_instances('FakeDataAgent')
+    assert 'fake-data-1' not in instances
 
 
 @patch('sorunlib.util.OCSClient', mock_registry_client)


### PR DESCRIPTION
This PR groups together a bunch of fixes from myself and @jlashner that were made during the first attempt at running the end to end system with real schedules generated by the scheduler. These changes can be summarized as:

* Updating deprecated API usage
* Identifying timezone used in the `wait()` command's target time
* Turning off the SMuRF streams if `scan()` crashes
* Removing some debug prints