### PR TITLE
Implement tolerance in wait command and rename to `wait_until`

### DIFF
--- a/docs/design.rst
+++ b/docs/design.rst
@@ -44,10 +44,10 @@ An example script in sorunlib looks like:
     initialize()
     smurf.set_targets(['smurf1'])
 
-    wait("2022-02-16 18:00:00")
+    wait_until("2022-02-16 18:00:00")
     acu.move_to(39.39, 64.27)
     smurf.iv_curve()
-    wait("2022-02-16 18:05:00")
+    wait_until("2022-02-16 18:05:00")
     smurf.bias_step()
     seq.scan("field")
     smurf.bias_step()

--- a/src/sorunlib/__init__.py
+++ b/src/sorunlib/__init__.py
@@ -1,6 +1,6 @@
 from . import acu, seq, smurf
 
-from .commands import wait
+from .commands import wait_until
 from .util import create_clients
 
 CLIENTS = None
@@ -18,7 +18,7 @@ def initialize(test_mode=False):
     CLIENTS = create_clients(test_mode=test_mode)
 
 
-__all__ = ["acu", "seq", "smurf", "wait", "initialize"]
+__all__ = ["acu", "seq", "smurf", "wait_until", "initialize"]
 
 from . import _version
 __version__ = _version.get_versions()['version']

--- a/src/sorunlib/commands.py
+++ b/src/sorunlib/commands.py
@@ -8,14 +8,15 @@ def wait_until(timestamp, tolerance=None):
     Args:
         timestamp (str): Time in ISO format and in UTC timezone to wait
             until, i.e. "2015-10-21T07:28:00", "2023-01-01T0:00:00+00:00"
-        tolerance (int or str): Tolerance on the difference between the time
-            when the function is evaluated and `timestamp`. Can be specified as
-            a ISO formatted timestamp (str) or in number of seconds (int).
+        tolerance (int, float, or str): Tolerance on the difference between the
+            time when the function is evaluated and `timestamp`. Can be
+            specified as a ISO formatted timestamp (str) or in number of
+            seconds (int, float).
 
             When evaluated, if `tolerance` (str) is in the past or if the
             difference between the current time and `timestamp` is greater than
-            this `tolerance` (int), then an error is raised. If `None`, an
-            error will not be raised. Default is `None`.
+            this `tolerance` (int, float), then an error is raised. If `None`,
+            an error will not be raised. Default is `None`.
 
     Raises:
         ValueError: If `timestamp` has an unsupported timezone, `tolerance`
@@ -38,7 +39,7 @@ def wait_until(timestamp, tolerance=None):
     # Determine "deadline" from tolerance
     if tolerance is None:
         deadline = None
-    elif isinstance(tolerance, int):
+    elif isinstance(tolerance, (int, float)):
         deadline = target + dt.timedelta(seconds=tolerance)
     elif isinstance(tolerance, str):
         deadline = dt.datetime.fromisoformat(tolerance)

--- a/src/sorunlib/commands.py
+++ b/src/sorunlib/commands.py
@@ -56,7 +56,8 @@ def wait_until(timestamp, tolerance=None):
     # Wait until timestamp
     if target > now:
         duration = (target - now).total_seconds()
+        print(f"Waiting for {duration} seconds")
+        time.sleep(duration)
     else:
-        duration = 0
-    print(f"Waiting for {duration} seconds")
-    time.sleep(duration)
+        diff = (now - target).total_seconds()
+        print(f"No wait, as target is {diff} seconds in the past")

--- a/src/sorunlib/commands.py
+++ b/src/sorunlib/commands.py
@@ -2,26 +2,60 @@ import time
 import datetime as dt
 
 
-def wait(target_time):
+def wait_until(timestamp, tolerance=None):
     """Wait until a specified time.
 
     Args:
-        target_time (str): Time in ISO format and in UTC timezone to wait
+        timestamp (str): Time in ISO format and in UTC timezone to wait
             until, i.e. "2015-10-21T07:28:00", "2023-01-01T0:00:00+00:00"
+        tolerance (int or str): Tolerance on the difference between the time
+            when the function is evaluated and `timestamp`. Can be specified as
+            a ISO formatted timestamp (str) or in number of seconds (int).
+
+            When evaluated, if `tolerance` (str) is in the past or if the
+            difference between the current time and `timestamp` is greater than
+            this `tolerance` (int), then an error is raised. If `None`, an
+            error will not be raised. Default is `None`.
+
+    Raises:
+        ValueError: If `timestamp` has an unsupported timezone, `tolerance`
+            is an unsupported type, or if the current time at evaluation is past
+            the threshold set by the `tolerance`.
 
     """
-    target = dt.datetime.fromisoformat(target_time)
-    TZ = target.tzinfo
+    target = dt.datetime.fromisoformat(timestamp)
 
+    # Determine timezone
+    TZ = target.tzinfo
     if TZ not in [None, dt.timezone.utc]:
         offset = target.tzinfo.tzname(None)
         raise ValueError(f'Unsupported timezone ({offset}) detected. '
                          + 'Timezone must be UTC.')
 
+    # Grab current TZ aware timestamp
     now = dt.datetime.now(TZ)
 
-    assert target > now, f"time {target} is in the past"
+    # Determine "deadline" from tolerance
+    if tolerance is None:
+        deadline = None
+    elif isinstance(tolerance, int):
+        deadline = target + dt.timedelta(seconds=tolerance)
+    elif isinstance(tolerance, str):
+        deadline = dt.datetime.fromisoformat(tolerance)
+    else:
+        raise ValueError(f"Unsupported type {type(tolerance)} provide for tolerance {tolerance}")
 
-    diff = target - now
-    print(f"Waiting for {diff.total_seconds()} seconds")
-    time.sleep(diff.total_seconds())
+    # Raise error if currently past the "deadline"
+    if deadline is None:
+        pass
+    elif now > deadline:
+        raise ValueError(f"Current time ({timestamp}) is past deadline "
+                         + f"({deadline.isoformat()}) set by tolerance ({tolerance})")
+
+    # Wait until timestamp
+    if target > now:
+        duration = (target - now).total_seconds()
+    else:
+        duration = 0
+    print(f"Waiting for {duration} seconds")
+    time.sleep(duration)

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -38,7 +38,7 @@ def scan(description, stop_time, width):
             raise Exception(f"Generate Scan failed to start:\n  {resp}")
 
         # Wait until stop time
-        run.commands.wait(stop_time)
+        run.commands.wait_until(stop_time)
 
         # Stop motion
         run.CLIENTS['acu'].generate_scan.stop()

--- a/tests/integration/test_example_script.py
+++ b/tests/integration/test_example_script.py
@@ -17,12 +17,12 @@ def mocked_clients(test_mode):
 def test_script():
     initialize()
     # wait until 1 second in future
-    wait((dt.datetime.now() + dt.timedelta(seconds=1)).isoformat())
+    wait_until((dt.datetime.now() + dt.timedelta(seconds=1)).isoformat())
     acu.move_to(39.39, 64.27)
     smurf.iv_curve()
     smurf.bias_step()
     # wait until 1 second in future
-    wait((dt.datetime.now() + dt.timedelta(seconds=1)).isoformat())
+    wait_until((dt.datetime.now() + dt.timedelta(seconds=1)).isoformat())
     seq.scan(description='test', stop_time=(dt.datetime.now()
              + dt.timedelta(seconds=1)).isoformat(), width=20.)
     smurf.bias_step()

--- a/tests/integration/test_example_script.py
+++ b/tests/integration/test_example_script.py
@@ -17,12 +17,12 @@ def mocked_clients(test_mode):
 def test_script():
     initialize()
     # wait until 1 second in future
-    wait_until((dt.datetime.now() + dt.timedelta(seconds=1)).isoformat())
+    wait_until((dt.datetime.utcnow() + dt.timedelta(seconds=1)).isoformat())
     acu.move_to(39.39, 64.27)
     smurf.iv_curve()
     smurf.bias_step()
     # wait until 1 second in future
-    wait_until((dt.datetime.now() + dt.timedelta(seconds=1)).isoformat())
-    seq.scan(description='test', stop_time=(dt.datetime.now()
+    wait_until((dt.datetime.utcnow() + dt.timedelta(seconds=1)).isoformat())
+    seq.scan(description='test', stop_time=(dt.datetime.utcnow()
              + dt.timedelta(seconds=1)).isoformat(), width=20.)
     smurf.bias_step()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,24 +5,69 @@ import datetime as dt
 
 from unittest.mock import MagicMock, patch
 
-from sorunlib.commands import wait
+from sorunlib.commands import wait_until
 
 
-@pytest.mark.parametrize("target_time", ["2020-01-01T00:00:00", "2020-01-01T00:00:00+00:00"])
-def test_wait_in_past(target_time):
-    with pytest.raises(AssertionError):
-        wait(target_time)
+def mkts(offset):
+    """Make timestamp.
+
+    Args:
+        offset (int): Offset from current time in seconds.
+
+    Returns:
+        str: ISO formatted timestamp 'offset' seconds from now, i.e.
+            '2023-04-22T00:59:56.264293+00:00'
+
+    Examples:
+        An example called at '2023-04-24T21:14:27.790440+00:00':
+
+        >>> mkts(1)
+        '2023-04-24T21:14:28.790440+00:00'
+
+    """
+    now = dt.datetime.now(dt.timezone.utc)
+    delta = dt.timedelta(seconds=offset)
+    ts = now + delta
+    return ts.isoformat()
 
 
-def test_wait_unsupported_tz():
+# patch out time.sleep so we don't actually sleep during testing
+@patch('sorunlib.commands.time.sleep', MagicMock())
+@pytest.mark.parametrize("timestamp,tolerance", [
+    # timestamp in past, not high enough tolerance
+    (mkts(-10), 5),
+    # timestamp in future, but past tolerance timestamp
+    (mkts(1), mkts(-1))])
+def test_wait_until_past_tolerance(timestamp, tolerance):
+    with pytest.raises(ValueError):
+        wait_until(timestamp, tolerance)
+
+
+@patch('sorunlib.commands.time.sleep', MagicMock())
+def test_wait_until_unsupported_tolerance():
+    with pytest.raises(ValueError):
+        wait_until(mkts(1), tolerance=[1, 2])
+
+
+def test_wait_until_unsupported_tz():
     with pytest.raises(ValueError):
         tz = dt.timezone(offset=dt.timedelta(hours=5))
         t = dt.datetime.now(tz).isoformat()  # i.e. '2023-04-22T00:59:56.264293+05:00'
-        wait(t)
+        wait_until(t)
 
 
-# patch out time.sleep so we don't actually wait during testing
 @patch('sorunlib.commands.time.sleep', MagicMock())
-def test_wait():
-    target = dt.datetime.now() + dt.timedelta(seconds=1)
-    wait(target.isoformat())
+@pytest.mark.parametrize("timestamp,tolerance", [
+    # timestamps in future, future or no tolerance
+    (mkts(1), None),
+    (mkts(1), 5),
+    (mkts(1), mkts(10)),
+    # timestamps in past, high enough or no tolerance
+    (mkts(-1), None),
+    (mkts(-1), 5),
+    (mkts(-1), mkts(10)),
+    # testing TZ detection w/past timestamps, no tolerance
+    ("2020-01-01T00:00:00", None),
+    ("2020-01-01T00:00:00+00:00", None)])
+def test_wait_until(timestamp, tolerance):
+    wait_until(timestamp, tolerance)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -66,6 +66,9 @@ def test_wait_until_unsupported_tz():
     (mkts(-1), None),
     (mkts(-1), 5),
     (mkts(-1), mkts(10)),
+    # test mix of tz aware timestamp, naive tolerance timestamp
+    (mkts(0), mkts(10)[:-6]),
+    (mkts(0)[:-6], mkts(10)),
     # testing TZ detection w/past timestamps, no tolerance
     ("2020-01-01T00:00:00", None),
     ("2020-01-01T00:00:00+00:00", None)])


### PR DESCRIPTION
## Description
During automated testing on the end to end system it became clear we needed some functionality like ACT's `soft_wait`, which allows `wait()` to pass, even if the timestamp provided is in the past at time of evaluation.

The new `tolerance` argument allows for "soft" waits, like the old ACT system, as well as setting a threshold on how stale a target timestamp can be before we raise an error.

Tolerance can be either an int (number of seconds past `timestamp`) or a str (in the form of an ISO formatted timestamp). `wait_until()` uses this to determine a hard cutoff "deadline", which if that has passed at time of evaluation, will cause an error.

### Tests
I added more test cases for this. They're a bit hard to read at first given they use "current" timestamps since "now()" is evaluated. So examples are all using `dt.timedelta` to make things relative to "now".

## Breaking API Change
This PR also renames `wait()` to `wait_until()`, which is a breaking API change. We're so early in development that I didn't bother to leave a stub of `wait()` in place either. The scheduler will need updating, but that should be it.