### PR TITLE
Always run motion stop commands after scan

### DIFF
--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -39,11 +39,11 @@ def scan(description, stop_time, width):
 
         # Wait until stop time
         run.commands.wait_until(stop_time)
-
+    finally:
         # Stop motion
         run.CLIENTS['acu'].generate_scan.stop()
         resp = run.CLIENTS['acu'].generate_scan.wait(timeout=OP_TIMEOUT)
         check_response(resp)
-    finally:
+
         # Stop SMuRF streams
         run.smurf.stream('off')


### PR DESCRIPTION
### Description
This PR moves the commands that stop the ACU motion to the finally block in the `seq.scan()` command. This'll ensure the telescope motion stops even when we interrupt or otherwise crash.

### Motivation
I noticed the scan motion continuing on the E2E system when I interrupted a scan, which then had to be stopped manually in order to resume running a schedule.

### Testing
Tested on the E2E system. Works well.