### PR TITLE
Add boresight control

### DIFF
--- a/src/sorunlib/acu.py
+++ b/src/sorunlib/acu.py
@@ -2,32 +2,34 @@ import sorunlib as run
 from sorunlib._internal import check_response
 
 
-def move_to(az, el, boresight=None):
+def move_to(az, el):
     """Move telescope to specified coordinates.
 
     Args:
         az (float): destination angle for the azimuthal axis
         el (float): destination angle for the elevation axis
-        boresight (float, optional): destination angle for boresight rotation
-            on SAT platforms
-
-    Raises:
-        RuntimeError: If boresight is passed to a non-satp platform.
 
     """
     # Az/El motion
     resp = run.CLIENTS['acu'].go_to(az=az, el=el)
     check_response(resp)
 
-    # Boresight motion (satp only)
-    if boresight is None:
-        return
 
+def set_boresight(target):
+    """Move the third axis to a specific target angle.
+
+    Args:
+        target (float): destination angle for boresight rotation
+
+    Raises:
+        RuntimeError: If boresight is passed to a non-satp platform.
+
+    """
     # Check platform type
     resp = run.CLIENTS['acu'].monitor.status()
     platform = resp.session['data']['PlatformType']
     if platform == "satp":
-        resp = run.CLIENTS['acu'].set_boresight(target=boresight)
+        resp = run.CLIENTS['acu'].set_boresight(target=target)
         check_response(resp)
     else:
         raise RuntimeError(f"Platform type {platform} does not support boresight motion")

--- a/src/sorunlib/acu.py
+++ b/src/sorunlib/acu.py
@@ -2,13 +2,32 @@ import sorunlib as run
 from sorunlib._internal import check_response
 
 
-def move_to(az, el):
+def move_to(az, el, boresight=None):
     """Move telescope to specified coordinates.
 
     Args:
         az (float): destination angle for the azimuthal axis
         el (float): destination angle for the elevation axis
+        boresight (float, optional): destination angle for boresight rotation
+            on SAT platforms
+
+    Raises:
+        RuntimeError: If boresight is passed to a non-satp platform.
 
     """
+    # Az/El motion
     resp = run.CLIENTS['acu'].go_to(az=az, el=el)
     check_response(resp)
+
+    # Boresight motion (satp only)
+    if boresight is None:
+        return
+
+    # Check platform type
+    resp = run.CLIENTS['acu'].monitor.status()
+    platform = resp.session['data']['PlatformType']
+    if platform == "satp":
+        resp = run.CLIENTS['acu'].set_boresight(target=boresight)
+        check_response(resp)
+    else:
+        raise RuntimeError(f"Platform type {platform} does not support boresight motion")

--- a/tests/test_acu.py
+++ b/tests/test_acu.py
@@ -43,20 +43,19 @@ def test_move_to():
 
 
 @patch('sorunlib.create_clients', mocked_clients)
-def test_move_to_boresight():
+def test_set_boresight():
     acu.run.initialize(test_mode=True)
     acu.run.CLIENTS['acu'] = create_acu_client('satp')
-    acu.move_to(180, 60, 20)
-    acu.run.CLIENTS['acu'].go_to.assert_called_with(az=180, el=60)
+    acu.set_boresight(20)
     acu.run.CLIENTS['acu'].set_boresight.assert_called_with(target=20)
 
 
 @patch('sorunlib.create_clients', mocked_clients)
-def test_move_to_boresight_lat():
+def test_set_boresight_lat():
     acu.run.initialize(test_mode=True)
     acu.run.CLIENTS['acu'] = create_acu_client('ccat')
     with pytest.raises(RuntimeError):
-        acu.move_to(180, 60, 20)
+        acu.set_boresight(20)
 
 
 @patch('sorunlib.create_clients', mocked_clients)

--- a/tests/test_acu.py
+++ b/tests/test_acu.py
@@ -5,8 +5,27 @@ import pytest
 
 from unittest.mock import MagicMock, patch
 
+import ocs
 from ocs.ocs_client import OCSReply
 from sorunlib import acu
+
+from util import create_session
+
+
+def create_acu_client(platform_type):
+    """Create an ACU client with mock monitor Process session.data.
+
+    Args:
+        platform_type (str): Either 'satp' or 'ccat'.
+
+    """
+    acu_client = MagicMock()
+    session = create_session('monitor')
+    session.data = {'PlatformType': platform_type}
+    reply = OCSReply(ocs.OK, 'msg', session.encoded())
+    acu_client.monitor.status = MagicMock(return_value=reply)
+
+    return acu_client
 
 
 def mocked_clients(test_mode):
@@ -21,6 +40,23 @@ def test_move_to():
     acu.run.initialize(test_mode=True)
     acu.move_to(180, 60)
     acu.run.CLIENTS['acu'].go_to.assert_called_with(az=180, el=60)
+
+
+@patch('sorunlib.create_clients', mocked_clients)
+def test_move_to_boresight():
+    acu.run.initialize(test_mode=True)
+    acu.run.CLIENTS['acu'] = create_acu_client('satp')
+    acu.move_to(180, 60, 20)
+    acu.run.CLIENTS['acu'].go_to.assert_called_with(az=180, el=60)
+    acu.run.CLIENTS['acu'].set_boresight.assert_called_with(target=20)
+
+
+@patch('sorunlib.create_clients', mocked_clients)
+def test_move_to_boresight_lat():
+    acu.run.initialize(test_mode=True)
+    acu.run.CLIENTS['acu'] = create_acu_client('ccat')
+    with pytest.raises(RuntimeError):
+        acu.move_to(180, 60, 20)
 
 
 @patch('sorunlib.create_clients', mocked_clients)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,11 @@
+from unittest import mock
+
+from ocs.ocs_agent import OpSession
+
+
+def create_session(op_name):
+    """Create an OpSession with a mocked app for testing."""
+    mock_app = mock.MagicMock()
+    session = OpSession(1, op_name, app=mock_app)
+
+    return session


### PR DESCRIPTION
This adds control of the SATP boresight via the ACU Agent's `set_boresight()` task.

I initially started to add this as a parameter in the existing `acu.move_to()` (see 7441c2537f1320667cc51d55cbdb926fe467fc7e), but after doing that decided it might be better to be a separate function (see 7441c2537f1320667cc51d55cbdb926fe467fc7e), since it's unique to the SATP.

Any thoughts on this construction definitely welcome.

Resolves #73.