### PR TITLE
Add ability to toggle SMuRF operation concurrency

### DIFF
--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -4,11 +4,9 @@ import sorunlib as run
 from sorunlib._internal import check_response
 
 # Timing between commanding separate SMuRF Controllers
-# Yet to be determined in the field.
-BIAS_STEP_WAIT = 0
-IV_CURVE_WAIT = 0
-UXM_SETUP_WAIT = 0
-UXM_RELOCK_WAIT = 0
+# Yet to be determined in the field. Eventually might need this to be unique
+# per operation. Also, move to configuration file once sorunlib has one.
+CRYO_WAIT = 120
 
 
 def set_targets(targets):
@@ -31,7 +29,7 @@ def set_targets(targets):
     run.CLIENTS['smurf'] = _smurf_clients
 
 
-def bias_step(tag=None, concurrent=True):
+def bias_step(tag=None, concurrent=True, settling_time=None):
     """Perform a bias step on all SMuRF Controllers.
 
     Args:
@@ -40,6 +38,11 @@ def bias_step(tag=None, concurrent=True):
         concurrent (bool, optional): A bool which determines how the operation
             is run across the active SMuRF controllers. It runs in parallel if
             True, and in series if False.
+        settling_time (float, optional):
+            Time in seconds to wait between operation runs across the active
+            SMuRF controlls if *not* running concurrently. If running
+            concurrently this is ignored. If None, defaults to a fixed wait
+            time of 120 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -49,7 +52,8 @@ def bias_step(tag=None, concurrent=True):
             check_response(resp)
 
             # Allow cryo to settle
-            time.sleep(BIAS_STEP_WAIT)
+            wait = settling_time if settling_time else CRYO_WAIT
+            time.sleep(wait)
 
     if concurrent:
         for smurf in run.CLIENTS['smurf']:
@@ -57,7 +61,7 @@ def bias_step(tag=None, concurrent=True):
             check_response(resp)
 
 
-def iv_curve(tag=None, concurrent=True):
+def iv_curve(tag=None, concurrent=True, settling_time=None):
     """Perform an iv curve on all SMuRF Controllers.
 
     Args:
@@ -66,6 +70,11 @@ def iv_curve(tag=None, concurrent=True):
         concurrent (bool, optional): A bool which determines how the operation
             is run across the active SMuRF controllers. It runs in parallel if
             True, and in series if False.
+        settling_time (float, optional):
+            Time in seconds to wait between operation runs across the active
+            SMuRF controlls if *not* running concurrently. If running
+            concurrently this is ignored. If None, defaults to a fixed wait
+            time of 120 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -75,7 +84,8 @@ def iv_curve(tag=None, concurrent=True):
             check_response(resp)
 
             # Allow cryo to settle
-            time.sleep(IV_CURVE_WAIT)
+            wait = settling_time if settling_time else CRYO_WAIT
+            time.sleep(wait)
 
     if concurrent:
         for smurf in run.CLIENTS['smurf']:
@@ -83,13 +93,18 @@ def iv_curve(tag=None, concurrent=True):
             check_response(resp)
 
 
-def uxm_setup(concurrent=True):
+def uxm_setup(concurrent=True, settling_time=None):
     """Perform first-time setup procedure for a UXM.
 
     Args:
         concurrent (bool, optional): A bool which determines how the operation
             is run across the active SMuRF controllers. It runs in parallel if
             True, and in series if False.
+        settling_time (float, optional):
+            Time in seconds to wait between operation runs across the active
+            SMuRF controlls if *not* running concurrently. If running
+            concurrently this is ignored. If None, defaults to a fixed wait
+            time of 120 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -99,7 +114,8 @@ def uxm_setup(concurrent=True):
             check_response(resp)
 
             # Allow cryo to settle
-            time.sleep(UXM_SETUP_WAIT)
+            wait = settling_time if settling_time else CRYO_WAIT
+            time.sleep(wait)
 
     if concurrent:
         for smurf in run.CLIENTS['smurf']:
@@ -107,7 +123,7 @@ def uxm_setup(concurrent=True):
             check_response(resp)
 
 
-def uxm_relock(test_mode=False, concurrent=True):
+def uxm_relock(test_mode=False, concurrent=True, settling_time=None):
     """Relocks detectors to existing tune if setup has already been run.
 
     Args:
@@ -116,6 +132,11 @@ def uxm_relock(test_mode=False, concurrent=True):
         concurrent (bool, optional): A bool which determines how the operation
             is run across the active SMuRF controllers. It runs in parallel if
             True, and in series if False.
+        settling_time (float, optional):
+            Time in seconds to wait between operation runs across the active
+            SMuRF controlls if *not* running concurrently. If running
+            concurrently this is ignored. If None, defaults to a fixed wait
+            time of 120 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -125,7 +146,8 @@ def uxm_relock(test_mode=False, concurrent=True):
             check_response(resp)
 
             # Allow cryo to settle
-            time.sleep(UXM_RELOCK_WAIT)
+            wait = settling_time if settling_time else CRYO_WAIT
+            time.sleep(wait)
 
     if concurrent:
         for smurf in run.CLIENTS['smurf']:
@@ -133,13 +155,18 @@ def uxm_relock(test_mode=False, concurrent=True):
             check_response(resp)
 
 
-def bias_dets(concurrent=True):
+def bias_dets(concurrent=True, settling_time=None):
     """Bias the detectors on all SMuRF Controllers.
 
     Args:
         concurrent (bool, optional): A bool which determines how the operation
             is run across the active SMuRF controllers. It runs in parallel if
             True, and in series if False.
+        settling_time (float, optional):
+            Time in seconds to wait between operation runs across the active
+            SMuRF controlls if *not* running concurrently. If running
+            concurrently this is ignored. If None, defaults to a fixed wait
+            time of 120 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -148,13 +175,17 @@ def bias_dets(concurrent=True):
             resp = smurf.bias_dets.wait()
             check_response(resp)
 
+            # Allow cryo to settle
+            wait = settling_time if settling_time else CRYO_WAIT
+            time.sleep(wait)
+
     if concurrent:
         for smurf in run.CLIENTS['smurf']:
             resp = smurf.bias_dets.wait()
             check_response(resp)
 
 
-def take_bgmap(tag=None, concurrent=True):
+def take_bgmap(tag=None, concurrent=True, settling_time=None):
     """Take a bgmap on all SMuRF Controllers.
 
     Args:
@@ -163,6 +194,11 @@ def take_bgmap(tag=None, concurrent=True):
         concurrent (bool, optional): A bool which determines how the operation
             is run across the active SMuRF controllers. It runs in parallel if
             True, and in series if False.
+        settling_time (float, optional):
+            Time in seconds to wait between operation runs across the active
+            SMuRF controlls if *not* running concurrently. If running
+            concurrently this is ignored. If None, defaults to a fixed wait
+            time of 120 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -171,13 +207,17 @@ def take_bgmap(tag=None, concurrent=True):
             resp = smurf.take_bgmap.wait()
             check_response(resp)
 
+            # Allow cryo to settle
+            wait = settling_time if settling_time else CRYO_WAIT
+            time.sleep(wait)
+
     if concurrent:
         for smurf in run.CLIENTS['smurf']:
             resp = smurf.take_bgmap.wait()
             check_response(resp)
 
 
-def take_noise(tag=None, concurrent=True):
+def take_noise(tag=None, concurrent=True, settling_time=None):
     """Measure noise statistics from a short, 30 second, timestream.
 
     Args:
@@ -186,6 +226,11 @@ def take_noise(tag=None, concurrent=True):
         concurrent (bool, optional): A bool which determines how the operation
             is run across the active SMuRF controllers. It runs in parallel if
             True, and in series if False.
+        settling_time (float, optional):
+            Time in seconds to wait between operation runs across the active
+            SMuRF controlls if *not* running concurrently. If running
+            concurrently this is ignored. If None, defaults to a fixed wait
+            time of 120 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -193,6 +238,10 @@ def take_noise(tag=None, concurrent=True):
         if not concurrent:
             resp = smurf.take_noise.wait()
             check_response(resp)
+
+            # Allow cryo to settle
+            wait = settling_time if settling_time else CRYO_WAIT
+            time.sleep(wait)
 
     if concurrent:
         for smurf in run.CLIENTS['smurf']:

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -93,7 +93,7 @@ def iv_curve(tag=None, concurrent=True, settling_time=None):
             check_response(resp)
 
 
-def uxm_setup(concurrent=True, settling_time=None):
+def uxm_setup(concurrent=True, settling_time=0):
     """Perform first-time setup procedure for a UXM.
 
     Args:
@@ -103,8 +103,7 @@ def uxm_setup(concurrent=True, settling_time=None):
         settling_time (float, optional):
             Time in seconds to wait between operation runs across the active
             SMuRF controlls if *not* running concurrently. If running
-            concurrently this is ignored. If None, defaults to a fixed wait
-            time of 120 seconds.
+            concurrently this is ignored. Defaults to 0 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -114,8 +113,7 @@ def uxm_setup(concurrent=True, settling_time=None):
             check_response(resp)
 
             # Allow cryo to settle
-            wait = settling_time if settling_time else CRYO_WAIT
-            time.sleep(wait)
+            time.sleep(settling_time)
 
     if concurrent:
         for smurf in run.CLIENTS['smurf']:
@@ -123,7 +121,7 @@ def uxm_setup(concurrent=True, settling_time=None):
             check_response(resp)
 
 
-def uxm_relock(test_mode=False, concurrent=True, settling_time=None):
+def uxm_relock(test_mode=False, concurrent=True, settling_time=0):
     """Relocks detectors to existing tune if setup has already been run.
 
     Args:
@@ -135,8 +133,7 @@ def uxm_relock(test_mode=False, concurrent=True, settling_time=None):
         settling_time (float, optional):
             Time in seconds to wait between operation runs across the active
             SMuRF controlls if *not* running concurrently. If running
-            concurrently this is ignored. If None, defaults to a fixed wait
-            time of 120 seconds.
+            concurrently this is ignored. Defaults to 0 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -146,8 +143,7 @@ def uxm_relock(test_mode=False, concurrent=True, settling_time=None):
             check_response(resp)
 
             # Allow cryo to settle
-            wait = settling_time if settling_time else CRYO_WAIT
-            time.sleep(wait)
+            time.sleep(settling_time)
 
     if concurrent:
         for smurf in run.CLIENTS['smurf']:
@@ -155,7 +151,7 @@ def uxm_relock(test_mode=False, concurrent=True, settling_time=None):
             check_response(resp)
 
 
-def bias_dets(concurrent=True, settling_time=None):
+def bias_dets(concurrent=True, settling_time=0):
     """Bias the detectors on all SMuRF Controllers.
 
     Args:
@@ -165,8 +161,7 @@ def bias_dets(concurrent=True, settling_time=None):
         settling_time (float, optional):
             Time in seconds to wait between operation runs across the active
             SMuRF controlls if *not* running concurrently. If running
-            concurrently this is ignored. If None, defaults to a fixed wait
-            time of 120 seconds.
+            concurrently this is ignored. Defaults to 0 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -176,8 +171,7 @@ def bias_dets(concurrent=True, settling_time=None):
             check_response(resp)
 
             # Allow cryo to settle
-            wait = settling_time if settling_time else CRYO_WAIT
-            time.sleep(wait)
+            time.sleep(settling_time)
 
     if concurrent:
         for smurf in run.CLIENTS['smurf']:
@@ -185,7 +179,7 @@ def bias_dets(concurrent=True, settling_time=None):
             check_response(resp)
 
 
-def take_bgmap(tag=None, concurrent=True, settling_time=None):
+def take_bgmap(tag=None, concurrent=True, settling_time=0):
     """Take a bgmap on all SMuRF Controllers.
 
     Args:
@@ -197,8 +191,7 @@ def take_bgmap(tag=None, concurrent=True, settling_time=None):
         settling_time (float, optional):
             Time in seconds to wait between operation runs across the active
             SMuRF controlls if *not* running concurrently. If running
-            concurrently this is ignored. If None, defaults to a fixed wait
-            time of 120 seconds.
+            concurrently this is ignored. Defaults to 0 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -208,8 +201,7 @@ def take_bgmap(tag=None, concurrent=True, settling_time=None):
             check_response(resp)
 
             # Allow cryo to settle
-            wait = settling_time if settling_time else CRYO_WAIT
-            time.sleep(wait)
+            time.sleep(settling_time)
 
     if concurrent:
         for smurf in run.CLIENTS['smurf']:
@@ -217,7 +209,7 @@ def take_bgmap(tag=None, concurrent=True, settling_time=None):
             check_response(resp)
 
 
-def take_noise(tag=None, concurrent=True, settling_time=None):
+def take_noise(tag=None, concurrent=True, settling_time=0):
     """Measure noise statistics from a short, 30 second, timestream.
 
     Args:
@@ -229,8 +221,7 @@ def take_noise(tag=None, concurrent=True, settling_time=None):
         settling_time (float, optional):
             Time in seconds to wait between operation runs across the active
             SMuRF controlls if *not* running concurrently. If running
-            concurrently this is ignored. If None, defaults to a fixed wait
-            time of 120 seconds.
+            concurrently this is ignored. Defaults to 0 seconds.
 
     """
     for smurf in run.CLIENTS['smurf']:
@@ -240,8 +231,7 @@ def take_noise(tag=None, concurrent=True, settling_time=None):
             check_response(resp)
 
             # Allow cryo to settle
-            wait = settling_time if settling_time else CRYO_WAIT
-            time.sleep(wait)
+            time.sleep(settling_time)
 
     if concurrent:
         for smurf in run.CLIENTS['smurf']:

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -4,10 +4,11 @@ import sorunlib as run
 from sorunlib._internal import check_response
 
 # Timing between commanding separate SMuRF Controllers
-BIAS_STEP_WAIT = 60
-IV_CURVE_WAIT = 60
-UXM_SETUP_WAIT = 60
-UXM_RELOCK_WAIT = 60
+# Yet to be determined in the field.
+BIAS_STEP_WAIT = 0
+IV_CURVE_WAIT = 0
+UXM_SETUP_WAIT = 0
+UXM_RELOCK_WAIT = 0
 
 
 def set_targets(targets):

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -1,5 +1,13 @@
+import time
+
 import sorunlib as run
 from sorunlib._internal import check_response
+
+# Timing between commanding separate SMuRF Controllers
+BIAS_STEP_WAIT = 60
+IV_CURVE_WAIT = 60
+UXM_SETUP_WAIT = 60
+UXM_RELOCK_WAIT = 60
 
 
 def set_targets(targets):
@@ -32,10 +40,11 @@ def bias_step(tag=None):
     """
     for smurf in run.CLIENTS['smurf']:
         smurf.take_bias_steps.start(tag=tag)
-
-    for smurf in run.CLIENTS['smurf']:
         resp = smurf.take_bias_steps.wait()
         check_response(resp)
+
+        # Allow cryo to settle
+        time.sleep(BIAS_STEP_WAIT)
 
 
 def iv_curve(tag=None):
@@ -48,20 +57,22 @@ def iv_curve(tag=None):
     """
     for smurf in run.CLIENTS['smurf']:
         smurf.take_iv.start(tag=tag)
-
-    for smurf in run.CLIENTS['smurf']:
         resp = smurf.take_iv.wait()
         check_response(resp)
+
+        # Allow cryo to settle
+        time.sleep(IV_CURVE_WAIT)
 
 
 def uxm_setup():
     """Perform first-time setup procedure for a UXM."""
     for smurf in run.CLIENTS['smurf']:
         smurf.uxm_setup.start()
-
-    for smurf in run.CLIENTS['smurf']:
         resp = smurf.uxm_setup.wait()
         check_response(resp)
+
+        # Allow cryo to settle
+        time.sleep(UXM_SETUP_WAIT)
 
 
 def uxm_relock(test_mode=False):
@@ -74,10 +85,11 @@ def uxm_relock(test_mode=False):
     """
     for smurf in run.CLIENTS['smurf']:
         smurf.uxm_relock.start(test_mode=test_mode)
-
-    for smurf in run.CLIENTS['smurf']:
         resp = smurf.uxm_relock.wait()
         check_response(resp)
+
+        # Allow cryo to settle
+        time.sleep(UXM_RELOCK_WAIT)
 
 
 def bias_dets():

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -30,108 +30,173 @@ def set_targets(targets):
     run.CLIENTS['smurf'] = _smurf_clients
 
 
-def bias_step(tag=None):
+def bias_step(tag=None, concurrent=True):
     """Perform a bias step on all SMuRF Controllers.
 
     Args:
         tag (str, optional): Tag or comma-separated listed of tags to attach to
             the operation.
+        concurrent (bool, optional): A bool which determines how the operation
+            is run across the active SMuRF controllers. It runs in parallel if
+            True, and in series if False.
 
     """
     for smurf in run.CLIENTS['smurf']:
         smurf.take_bias_steps.start(tag=tag)
-        resp = smurf.take_bias_steps.wait()
-        check_response(resp)
+        if not concurrent:
+            resp = smurf.take_bias_steps.wait()
+            check_response(resp)
 
-        # Allow cryo to settle
-        time.sleep(BIAS_STEP_WAIT)
+            # Allow cryo to settle
+            time.sleep(BIAS_STEP_WAIT)
+
+    if concurrent:
+        for smurf in run.CLIENTS['smurf']:
+            resp = smurf.take_bias_steps.wait()
+            check_response(resp)
 
 
-def iv_curve(tag=None):
+def iv_curve(tag=None, concurrent=True):
     """Perform an iv curve on all SMuRF Controllers.
 
     Args:
         tag (str, optional): Tag or comma-separated listed of tags to attach to
             the operation.
+        concurrent (bool, optional): A bool which determines how the operation
+            is run across the active SMuRF controllers. It runs in parallel if
+            True, and in series if False.
 
     """
     for smurf in run.CLIENTS['smurf']:
         smurf.take_iv.start(tag=tag)
-        resp = smurf.take_iv.wait()
-        check_response(resp)
+        if not concurrent:
+            resp = smurf.take_iv.wait()
+            check_response(resp)
 
-        # Allow cryo to settle
-        time.sleep(IV_CURVE_WAIT)
+            # Allow cryo to settle
+            time.sleep(IV_CURVE_WAIT)
+
+    if concurrent:
+        for smurf in run.CLIENTS['smurf']:
+            resp = smurf.take_iv.wait()
+            check_response(resp)
 
 
-def uxm_setup():
-    """Perform first-time setup procedure for a UXM."""
+def uxm_setup(concurrent=True):
+    """Perform first-time setup procedure for a UXM.
+
+    Args:
+        concurrent (bool, optional): A bool which determines how the operation
+            is run across the active SMuRF controllers. It runs in parallel if
+            True, and in series if False.
+
+    """
     for smurf in run.CLIENTS['smurf']:
         smurf.uxm_setup.start()
-        resp = smurf.uxm_setup.wait()
-        check_response(resp)
+        if not concurrent:
+            resp = smurf.uxm_setup.wait()
+            check_response(resp)
 
-        # Allow cryo to settle
-        time.sleep(UXM_SETUP_WAIT)
+            # Allow cryo to settle
+            time.sleep(UXM_SETUP_WAIT)
+
+    if concurrent:
+        for smurf in run.CLIENTS['smurf']:
+            resp = smurf.uxm_setup.wait()
+            check_response(resp)
 
 
-def uxm_relock(test_mode=False):
+def uxm_relock(test_mode=False, concurrent=True):
     """Relocks detectors to existing tune if setup has already been run.
 
     Args:
         test_mode (bool): Run uxm_setup() task in test_mode, removing emulated
             wait times.
+        concurrent (bool, optional): A bool which determines how the operation
+            is run across the active SMuRF controllers. It runs in parallel if
+            True, and in series if False.
 
     """
     for smurf in run.CLIENTS['smurf']:
         smurf.uxm_relock.start(test_mode=test_mode)
-        resp = smurf.uxm_relock.wait()
-        check_response(resp)
+        if not concurrent:
+            resp = smurf.uxm_relock.wait()
+            check_response(resp)
 
-        # Allow cryo to settle
-        time.sleep(UXM_RELOCK_WAIT)
+            # Allow cryo to settle
+            time.sleep(UXM_RELOCK_WAIT)
+
+    if concurrent:
+        for smurf in run.CLIENTS['smurf']:
+            resp = smurf.uxm_relock.wait()
+            check_response(resp)
 
 
-def bias_dets():
-    """Bias the detectors on all SMuRF Controllers."""
+def bias_dets(concurrent=True):
+    """Bias the detectors on all SMuRF Controllers.
+
+    Args:
+        concurrent (bool, optional): A bool which determines how the operation
+            is run across the active SMuRF controllers. It runs in parallel if
+            True, and in series if False.
+
+    """
     for smurf in run.CLIENTS['smurf']:
         smurf.bias_dets.start()
+        if not concurrent:
+            resp = smurf.bias_dets.wait()
+            check_response(resp)
 
-    for smurf in run.CLIENTS['smurf']:
-        resp = smurf.bias_dets.wait()
-        check_response(resp)
+    if concurrent:
+        for smurf in run.CLIENTS['smurf']:
+            resp = smurf.bias_dets.wait()
+            check_response(resp)
 
 
-def take_bgmap(tag=None):
+def take_bgmap(tag=None, concurrent=True):
     """Take a bgmap on all SMuRF Controllers.
 
     Args:
         tag (str, optional): Tag or comma-separated listed of tags to attach to
             the operation.
+        concurrent (bool, optional): A bool which determines how the operation
+            is run across the active SMuRF controllers. It runs in parallel if
+            True, and in series if False.
 
     """
     for smurf in run.CLIENTS['smurf']:
         smurf.take_bgmap.start(tag=tag)
+        if not concurrent:
+            resp = smurf.take_bgmap.wait()
+            check_response(resp)
 
-    for smurf in run.CLIENTS['smurf']:
-        resp = smurf.take_bgmap.wait()
-        check_response(resp)
+    if concurrent:
+        for smurf in run.CLIENTS['smurf']:
+            resp = smurf.take_bgmap.wait()
+            check_response(resp)
 
 
-def take_noise(tag=None):
+def take_noise(tag=None, concurrent=True):
     """Measure noise statistics from a short, 30 second, timestream.
 
     Args:
         tag (str, optional): Tag or comma-separated listed of tags to attach to
             the operation.
+        concurrent (bool, optional): A bool which determines how the operation
+            is run across the active SMuRF controllers. It runs in parallel if
+            True, and in series if False.
 
     """
     for smurf in run.CLIENTS['smurf']:
         smurf.take_noise.start(tag=tag)
+        if not concurrent:
+            resp = smurf.take_noise.wait()
+            check_response(resp)
 
-    for smurf in run.CLIENTS['smurf']:
-        resp = smurf.take_noise.wait()
-        check_response(resp)
+    if concurrent:
+        for smurf in run.CLIENTS['smurf']:
+            resp = smurf.take_noise.wait()
+            check_response(resp)
 
 
 def stream(state, tag=None, subtype=None):

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -3,6 +3,8 @@ os.environ["OCS_CONFIG_DIR"] = "./test_util/"
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from sorunlib import smurf
 
 
@@ -33,60 +35,67 @@ def test_set_targets():
 
 @patch('sorunlib.smurf.time.sleep', MagicMock())
 @patch('sorunlib.create_clients', mocked_clients)
-def test_bias_step():
+@pytest.mark.parametrize("concurrent", [(True), (False)])
+def test_bias_step(concurrent):
     smurf.run.initialize(test_mode=True)
-    smurf.bias_step()
+    smurf.bias_step(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.take_bias_steps.start.assert_called_once()
 
 
 @patch('sorunlib.smurf.time.sleep', MagicMock())
 @patch('sorunlib.create_clients', mocked_clients)
-def test_iv_curve():
+@pytest.mark.parametrize("concurrent", [(True), (False)])
+def test_iv_curve(concurrent):
     smurf.run.initialize(test_mode=True)
-    smurf.iv_curve()
+    smurf.iv_curve(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.take_iv.start.assert_called_once()
 
 
 @patch('sorunlib.smurf.time.sleep', MagicMock())
 @patch('sorunlib.create_clients', mocked_clients)
-def test_uxm_setup():
+@pytest.mark.parametrize("concurrent", [(True), (False)])
+def test_uxm_setup(concurrent):
     smurf.run.initialize(test_mode=True)
-    smurf.uxm_setup()
+    smurf.uxm_setup(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.uxm_setup.start.assert_called_once()
 
 
 @patch('sorunlib.smurf.time.sleep', MagicMock())
 @patch('sorunlib.create_clients', mocked_clients)
-def test_uxm_relock():
+@pytest.mark.parametrize("concurrent", [(True), (False)])
+def test_uxm_relock(concurrent):
     smurf.run.initialize(test_mode=True)
-    smurf.uxm_relock()
+    smurf.uxm_relock(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.uxm_relock.start.assert_called_once()
 
 
 @patch('sorunlib.create_clients', mocked_clients)
-def test_bias_dets():
+@pytest.mark.parametrize("concurrent", [(True), (False)])
+def test_bias_dets(concurrent):
     smurf.run.initialize(test_mode=True)
-    smurf.bias_dets()
+    smurf.bias_dets(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.bias_dets.start.assert_called_once()
 
 
 @patch('sorunlib.create_clients', mocked_clients)
-def test_bgmap():
+@pytest.mark.parametrize("concurrent", [(True), (False)])
+def test_bgmap(concurrent):
     smurf.run.initialize(test_mode=True)
-    smurf.take_bgmap()
+    smurf.take_bgmap(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.take_bgmap.start.assert_called_once()
 
 
 @patch('sorunlib.create_clients', mocked_clients)
-def test_take_noise():
+@pytest.mark.parametrize("concurrent", [(True), (False)])
+def test_take_noise(concurrent):
     smurf.run.initialize(test_mode=True)
-    smurf.take_noise()
+    smurf.take_noise(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.take_noise.start.assert_called_once()
 

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -31,6 +31,7 @@ def test_set_targets():
     assert smurf.run.CLIENTS['smurf'][0].instance_id == 'smurf1'
 
 
+@patch('sorunlib.smurf.time.sleep', MagicMock())
 @patch('sorunlib.create_clients', mocked_clients)
 def test_bias_step():
     smurf.run.initialize(test_mode=True)
@@ -39,6 +40,7 @@ def test_bias_step():
         client.take_bias_steps.start.assert_called_once()
 
 
+@patch('sorunlib.smurf.time.sleep', MagicMock())
 @patch('sorunlib.create_clients', mocked_clients)
 def test_iv_curve():
     smurf.run.initialize(test_mode=True)
@@ -47,6 +49,7 @@ def test_iv_curve():
         client.take_iv.start.assert_called_once()
 
 
+@patch('sorunlib.smurf.time.sleep', MagicMock())
 @patch('sorunlib.create_clients', mocked_clients)
 def test_uxm_setup():
     smurf.run.initialize(test_mode=True)
@@ -55,6 +58,7 @@ def test_uxm_setup():
         client.uxm_setup.start.assert_called_once()
 
 
+@patch('sorunlib.smurf.time.sleep', MagicMock())
 @patch('sorunlib.create_clients', mocked_clients)
 def test_uxm_relock():
     smurf.run.initialize(test_mode=True)


### PR DESCRIPTION
Draft for now, as there are maybe some details to work out/things to clean up, but since it might be needed soon I wanted to make something available. This is functional for now, all `smurf.*` commands run in parallel by default and if passed `concurrent=False` will run serially, currently with no wait time in between different controllers.