### PR TITLE
Create wiregrid calibration module

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,3 +50,12 @@ sorunlib.util
     :members:
     :undoc-members:
     :show-inheritance:
+
+
+sorunlib.wiregrid
+-----------------
+
+.. automodule:: sorunlib.wiregrid
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -26,6 +26,10 @@ A full configuration file example with comments is shown here:
     # ocs registry agent
     registry: 'registry'
 
+    # wiregrid agents
+    wiregrid:
+      labjack: 'wg-labjack'
+
 Configuration Selection
 -----------------------
 

--- a/src/sorunlib/__init__.py
+++ b/src/sorunlib/__init__.py
@@ -1,4 +1,4 @@
-from . import acu, seq, smurf
+from . import acu, seq, smurf, wiregrid
 
 from .commands import wait_until
 from .util import create_clients
@@ -18,7 +18,7 @@ def initialize(test_mode=False):
     CLIENTS = create_clients(test_mode=test_mode)
 
 
-__all__ = ["acu", "seq", "smurf", "wait_until", "initialize"]
+__all__ = ["acu", "seq", "smurf", "wiregrid", "wait_until", "initialize"]
 
 from . import _version
 __version__ = _version.get_versions()['version']

--- a/src/sorunlib/_internal.py
+++ b/src/sorunlib/_internal.py
@@ -7,6 +7,21 @@ The usual caveats apply, these interfaces might change without notice.
 import ocs
 
 
+def _check_error(client, response):
+    """Check if a response is an error or timeout."""
+    op = response.session['op_name']
+    instance = client.instance_id
+
+    if response.status == ocs.ERROR:
+        error = f"Request for Operation {op} in Agent {instance} failed.\n" + \
+            str(response)
+        raise RuntimeError(error)
+    elif response.status == ocs.TIMEOUT:
+        error = f"Timeout reached waiting for {op} in Agent {instance} to " + \
+            "complete.\n" + str(response)
+        raise RuntimeError(error)
+
+
 def check_response(client, response):
     """Check that a response from OCS indicates successful task/process
     completion.
@@ -25,16 +40,33 @@ def check_response(client, response):
     op = response.session['op_name']
     instance = client.instance_id
 
-    if response.status == ocs.ERROR:
-        error = f"Request for Operation {op} in Agent {instance} failed.\n" + \
-            str(response)
-        raise RuntimeError(error)
-    elif response.status == ocs.TIMEOUT:
-        error = f"Timeout reached waiting for {op} in Agent {instance} to " + \
-            "complete.\n" + str(response)
-        raise RuntimeError(error)
+    _check_error(client, response)
 
     if not response.session['success']:
         error = f'Task {op} in Agent {instance} failed to complete " + \
             "successfully.\n' + str(response)
+        raise RuntimeError(error)
+
+
+def check_running(client, response):
+    """Check that a response from OCS indicates a task/process is still
+    running.
+
+    Args:
+        client (ocs.ocs_client.OCSClient): OCS Client which returned the
+            response.
+        response (ocs.ocs_client.OCSReply): Response from an OCS operation
+            call.
+
+    Raises:
+        RuntimeError: When Operation is not running.
+
+    """
+    op = response.session['op_name']
+    instance = client.instance_id
+
+    _check_error(client, response)
+    if response.session['status'] != 'running':
+        error = f"Operation {op} in Agent {instance} is not in the 'running' " + \
+                "state.\n" + str(response)
         raise RuntimeError(error)

--- a/src/sorunlib/util.py
+++ b/src/sorunlib/util.py
@@ -119,6 +119,35 @@ def _try_client(instanceid):
     return client
 
 
+def _create_wiregrid_clients(config=None, sorunlib_config=None):
+    """Create all wiregrid related clients for a single platform.
+
+    Args:
+        config (str): Path to the OCS Site Config File. If None the default
+            file in OCS_CONFIG_DIR will be used.
+        sorunlib_config (str): Path to sorunlib config file. If None the path
+            from environment variable SORUNLIB_CONFIG is used.
+
+    Returns:
+        dict: Dictionary with the keys, 'acutator', 'encoder', 'kikusui', and
+            'labjack' with each value being the corresponding OCSClient.
+
+    """
+    actuator = _find_active_instances('WiregridActuatorAgent')
+    encoder = _find_active_instances('WiregridEncoderAgent')
+    kikusui = _find_active_instances('WiregridKikusuiAgent')
+
+    cfg = load_config(filename=sorunlib_config)
+    labjack = cfg['wiregrid']['labjack']
+
+    clients = {'actuator': _try_client(actuator),
+               'encoder': _try_client(encoder),
+               'kikusui': _try_client(kikusui),
+               'labjack': _try_client(labjack)}
+
+    return clients
+
+
 def create_clients(config=None, test_mode=False):
     """Create all clients needed for commanding a single platform.
 
@@ -134,7 +163,11 @@ def create_clients(config=None, test_mode=False):
         in the format::
 
             clients = {'acu': acu_client,
-                       'smurf': [smurf_client1, smurf_client2, smurf_client3]}
+                       'smurf': [smurf_client1, smurf_client2, smurf_client3],
+                       'wiregrid': {'actuator': actuator_client,
+                                    'encoder': encoder_client,
+                                    'kikusui': kikusui_client,
+                                    'labjack': labjack_client}}
 
     """
     clients = {}
@@ -154,5 +187,7 @@ def create_clients(config=None, test_mode=False):
     # Always create smurf client list, even if empty
     smurf_clients = [_try_client(x) for x in smurf_ids]
     clients['smurf'] = smurf_clients
+
+    clients['wiregrid'] = _create_wiregrid_clients(config=config)
 
     return clients

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -183,6 +183,30 @@ def _check_temperature_sensors():
 
 
 # Public API
+def insert():
+    """Insert the wiregrid."""
+    actuator = run.CLIENTS['wiregrid']['actuator']
+    resp = actuator.insert()
+    try:
+        check_response(actuator, resp)
+    except RuntimeError as e:
+        error = "Wiregrid insertion failed. Please inspect wiregrid before " + \
+                "continuing observations.\n" + str(e)
+        raise RuntimeError(error)
+
+
+def eject():
+    """Eject the wiregrid."""
+    actuator = run.CLIENTS['wiregrid']['actuator']
+    resp = actuator.eject()
+    try:
+        check_response(actuator, resp)
+    except RuntimeError as e:
+        error = "Wiregrid eject failed. Please inspect wiregrid before " + \
+                "continuing observations.\n" + str(e)
+        raise RuntimeError(error)
+
+
 def calibrate(continuous=False):
     """Run a wiregrid calibration.
 
@@ -192,7 +216,6 @@ def calibrate(continuous=False):
 
     """
     # Organize wiregrid clients
-    actuator = run.CLIENTS['wiregrid']['actuator']
     kikusui = run.CLIENTS['wiregrid']['kikusui']
 
     try:
@@ -216,13 +239,7 @@ def calibrate(continuous=False):
         run.smurf.stream('on', tag=f'wiregrid, {rotation}', subtype='cal')
 
         # Insert the wiregrid
-        resp = actuator.insert()
-        try:
-            check_response(actuator, resp)
-        except RuntimeError as e:
-            error = "Wiregrid insertion failed. Please inspect wiregrid before " + \
-                    "continuing observations.\n" + str(e)
-            raise RuntimeError(error)
+        insert()
 
         # Rotate the wiregrid
         if continuous:
@@ -232,13 +249,7 @@ def calibrate(continuous=False):
             check_response(kikusui, resp)
 
         # Eject the wiregrid
-        resp = actuator.eject()
-        try:
-            check_response(actuator, resp)
-        except RuntimeError as e:
-            error = "Wiregrid eject failed. Please inspect wiregrid before " + \
-                    "continuing observations.\n" + str(e)
-            raise RuntimeError(error)
+        eject()
     finally:
         # Stop SMuRF streams
         run.smurf.stream('off')

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -1,0 +1,244 @@
+import time
+
+import sorunlib as run
+from sorunlib._internal import check_response, check_running
+
+EL_DIFF_THRESHOLD = 0.5  # deg diff from 50 that its ok to run calibration
+BORESIGHT_DIFF_THRESHOLD = 0.5  # deg
+AGENT_TIMEDIFF_THRESHOLD = 5  # sec
+OP_TIMEOUT = 60
+
+CONTINUOUS_ROTATION_TIME = 30  # sec
+
+
+# Internal Helper Functions
+def _check_process_data(process, last_timestamp):
+    """Check the latest timestamp from a process' session.data is recent enough.
+
+    Args:
+        process (str): Descriptive name, used in the error message.
+        last_timestamp (float): Latest timestamp from the session.data.
+
+    Raises:
+        RuntimeError: When the last timestamp was more than
+            AGENT_TIMEDIFF_THRESHOLD old.
+
+    """
+    try:
+        assert ((time.time() - last_timestamp) < AGENT_TIMEDIFF_THRESHOLD)
+    except AssertionError:
+        error = f"{process} has no updated data. Cannot proceed with " + \
+                "wiregrid calibration. Aborting."
+        raise RuntimeError(error)
+
+
+def _verify_temp_response(response, sensor, min_temp):
+    """Check temperature above minimum temperation for safe operation of wiregrid.
+
+    Args:
+        response (ocs.ocs_client.OCSReply): Client response from the labjack
+            acq process.
+        sensor (str): Sensor name in the labjack session data, i.e. 'AIN0'.
+        min_temp (int, float): Minimum temperature for safe operation in C.
+
+    Raises:
+        RuntimeError: When the temperature of sensor below ``min_temp``.
+
+    """
+    temp = response.session['data']['data'][sensor]
+    try:
+        assert (temp > min_temp)
+    except AssertionError:
+        error = f"Sensor {sensor} reads {temp} C, which is below minimum " + \
+                f"temperature of {min_temp} C. Cannot proceed with wiregrid " + \
+                "calibration. Aborting"
+        raise RuntimeError(error)
+
+
+# Calibration Functions
+def _check_telescope_position():
+    # Get current telescope position
+    acu = run.CLIENTS['acu']
+    resp = acu.monitor.status()
+    az = resp.session['data']['StatusDetailed']['Azimuth current position']
+    el = resp.session['data']['StatusDetailed']['Elevation current position']
+    boresight = resp.session['data']['StatusDetailed']['Boresight current position']
+
+    # Check appropriate elevation
+    try:
+        assert (abs(el - 50) < EL_DIFF_THRESHOLD)
+    except AssertionError:
+        error = "Telescope not at 50 deg elevation. Cannot proceed with " + \
+                f"wiregrid calibration in current position ({az}, {el}). " + \
+                "Aborting."
+        raise RuntimeError(error)
+
+    # Check boresight angle
+    try:
+        assert (abs(boresight - 0) < BORESIGHT_DIFF_THRESHOLD)
+    except AssertionError:
+        error = "Telescope not at 0 deg boresight. Cannot proceed with " + \
+                f"wiregrid calibration in current position ({boresight}). " + \
+                "Aborting."
+        raise RuntimeError(error)
+
+
+def _configure_power(continuous):
+    """Configure the KIKUSUI power supply for rotation based on rotation type.
+
+    Args:
+        continuous (bool): Configure for continuous rotation or not.
+
+    """
+    kikusui = run.CLIENTS['wiregrid']['kikusui']
+
+    resp = kikusui.set_v(volt=12)
+    check_response(kikusui, resp)
+
+    if continuous:
+        current = 3.0
+    else:
+        current = 2.4
+
+    resp = kikusui.set_c(current=current)
+    check_response(kikusui, resp)
+
+
+def _rotate_continuously(duration):
+    kikusui = run.CLIENTS['wiregrid']['kikusui']
+
+    # Start rotation
+    resp = kikusui.set_on()
+    check_response(kikusui, resp)
+
+    # Wait
+    time.sleep(duration)
+
+    # Stop rotation
+    resp = kikusui.set_off()
+    check_response(kikusui, resp)
+
+
+def _check_motor_on():
+    actuator = run.CLIENTS['wiregrid']['actuator']
+
+    # Check motor is on
+    resp = actuator.acq.status()
+    if resp.session['data']['fields']['motor'] == 1:
+        print("Wiregrid motor already on.")
+    # Turn on motor if needed
+    elif resp.session['data']['fields']['motor'] == 0:
+        resp = actuator.motor_on()
+        check_response(actuator, resp)
+    else:
+        raise RuntimeError("Motor state unknown. Aborting...")
+
+
+def _check_agents_online():
+    """Check OCS agents related to the wiregrid are running."""
+    actuator = run.CLIENTS['wiregrid']['actuator']
+    kikusui = run.CLIENTS['wiregrid']['kikusui']
+    encoder = run.CLIENTS['wiregrid']['encoder']
+    labjack = run.CLIENTS['wiregrid']['labjack']
+
+    # wiregrid_actuator
+    resp = actuator.acq.status()
+    last_timestamp = resp.session['data']['timestamp']
+    check_running(actuator, resp)
+    _check_process_data("Actuator agent", last_timestamp)
+
+    # wiregrid_kikusui
+    resp = kikusui.IV_acq.status()
+    last_timestamp = resp.session['data']['timestamp']
+    check_running(kikusui, resp)
+    _check_process_data("Kikusui agent", last_timestamp)
+
+    # wiregrid_encoder
+    resp = encoder.acq.status()
+    last_timestamp = resp.session['data']['timestamp']
+    check_running(encoder, resp)
+    _check_process_data("Encoder agent", last_timestamp)
+
+    # labjack
+    resp = labjack.acq.status()
+    last_timestamp = resp.session['data']['timestamp']
+    check_running(labjack, resp)
+    _check_process_data("Labjack agent", last_timestamp)
+
+    # encoder data stream
+    resp = encoder.acq.status()
+    last_timestamp = resp.session['data']['fields']['encoder_data']['last_updated']
+    _check_process_data("Encoder BBB", last_timestamp)
+
+
+def _check_temperature_sensors():
+    """Check temperatures within safe range."""
+    labjack = run.CLIENTS['wiregrid']['labjack']
+    resp = labjack.acq.status()
+    # AIN0 > -10 C && AIN1 > -10 C (On the wiregrid)
+    _verify_temp_response(resp, 'AIN0', -10)
+    _verify_temp_response(resp, 'AIN1', -10)
+    # AIN2 > 0 C (Inside the electronics enclosure for the gridloader)
+    _verify_temp_response(resp, 'AIN2', 0)
+
+
+# Public API
+def calibrate(continuous=False):
+    """Run a wiregrid calibration.
+
+    Args:
+        continuous (bool): Calibration by continuous rotation or not.
+            Default is False, in which the wiregrid rotates step-wisely.
+
+    """
+    # Organize wiregrid clients
+    actuator = run.CLIENTS['wiregrid']['actuator']
+    kikusui = run.CLIENTS['wiregrid']['kikusui']
+
+    try:
+        _check_telescope_position()
+        _check_agents_online()
+        _check_temperature_sensors()
+        _check_motor_on()
+
+        # Rotate for reference before insertion
+        _configure_power(continuous=True)
+        _rotate_continuously(5)
+
+        # Configure power
+        _configure_power(continuous)
+
+        # Enable SMuRF streams
+        if continuous:
+            rotation = 'continuous'
+        else:
+            rotation = 'stepwise'
+        run.smurf.stream('on', tag=f'wiregrid, {rotation}', subtype='cal')
+
+        # Insert the wiregrid
+        resp = actuator.insert()
+        try:
+            check_response(actuator, resp)
+        except RuntimeError as e:
+            error = "Wiregrid insertion failed. Please inspect wiregrid before " + \
+                    "continuing observations.\n" + str(e)
+            raise RuntimeError(error)
+
+        # Rotate the wiregrid
+        if continuous:
+            _rotate_continuously(CONTINUOUS_ROTATION_TIME)
+        else:
+            resp = kikusui.stepwise_rotation(num_laps=1, stopped_time=10.0)
+            check_response(kikusui, resp)
+
+        # Eject the wiregrid
+        resp = actuator.eject()
+        try:
+            check_response(actuator, resp)
+        except RuntimeError as e:
+            error = "Wiregrid eject failed. Please inspect wiregrid before " + \
+                    "continuing observations.\n" + str(e)
+            raise RuntimeError(error)
+    finally:
+        # Stop SMuRF streams
+        run.smurf.stream('off')

--- a/tests/data/example_config.yaml
+++ b/tests/data/example_config.yaml
@@ -1,2 +1,4 @@
 ---
 registry: 'registry'
+wiregrid:
+  labjack: 'wg-labjack'

--- a/tests/test__internal.py
+++ b/tests/test__internal.py
@@ -6,16 +6,18 @@ from unittest.mock import MagicMock
 from ocs.ocs_agent import OpSession
 from ocs.ocs_client import OCSReply
 
-from sorunlib._internal import check_response
+from sorunlib._internal import check_response, check_running
 
 os.environ["OCS_CONFIG_DIR"] = "./test_util/"
 
 
-def create_session(op_name, success=None):
+def create_session(op_name, status=None, success=None):
     """Create an OpSession with a mocked app for testing."""
     mock_app = MagicMock()
     session = OpSession(1, op_name, app=mock_app)
     session.op_name = 'test_op'
+    if status is not None:
+        session.set_status(status)
     session.success = success
 
     return session.encoded()
@@ -32,10 +34,16 @@ invalid_responses = [(MockClient(), OCSReply(ocs.TIMEOUT,
                                              create_session('test', success=True))),
                      (MockClient(), OCSReply(ocs.ERROR,
                                              'msg',
-                                             create_session('test')))]
+                                             create_session('test', success=False)))]
 
 valid_responses = [
     (MockClient(), OCSReply(ocs.OK, 'msg', create_session('test', success=True)))]
+
+invalid_running_responses = [
+    (MockClient(), OCSReply(ocs.OK, 'msg', create_session('test')))]
+
+running_responses = [
+    (MockClient(), OCSReply(ocs.OK, 'msg', create_session('test', status='running')))]
 
 
 @pytest.mark.parametrize("client,response", invalid_responses)
@@ -47,3 +55,14 @@ def test_check_response_raises(client, response):
 @pytest.mark.parametrize("client,response", valid_responses)
 def test_check_response(client, response):
     check_response(client, response)
+
+
+@pytest.mark.parametrize("client,response", invalid_running_responses)
+def test_check_running_raises(client, response):
+    with pytest.raises(RuntimeError):
+        check_running(client, response)
+
+
+@pytest.mark.parametrize("client,response", running_responses)
+def test_check_running(client, response):
+    check_running(client, response)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,9 +7,11 @@ from sorunlib.config import load_config
 
 def test_load_config():
     cfg = load_config("./data/example_config.yaml")
-    assert cfg == {'registry': 'registry'}
+    assert cfg == {'registry': 'registry',
+                   'wiregrid': {'labjack': 'wg-labjack'}}
 
 
 def test_load_config_from_env():
     cfg = load_config()
-    assert cfg == {'registry': 'registry'}
+    assert cfg == {'registry': 'registry',
+                   'wiregrid': {'labjack': 'wg-labjack'}}

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,6 +8,7 @@ from sorunlib import util
 from sorunlib.util import CrossbarConnectionError
 
 os.environ["OCS_CONFIG_DIR"] = "./test_util/"
+os.environ["SORUNLIB_CONFIG"] = "./data/example_config.yaml"
 
 
 # I think this could be generalized with the Mock 'spec' argument, building an
@@ -158,6 +159,7 @@ def test_create_clients():
     assert 'acu' in clients
     assert 'smurf' in clients
     assert len(clients['smurf']) == 0  # since we're not in test_mode
+    assert 'wiregrid' in clients
 
 
 @patch('sorunlib.util.OCSClient', mock_registry_client)
@@ -166,3 +168,4 @@ def test_create_clients_test_mode():
     assert 'acu' in clients
     assert 'smurf' in clients
     assert len(clients['smurf']) == 2
+    assert 'wiregrid' in clients

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -1,0 +1,268 @@
+import os
+import time
+os.environ["OCS_CONFIG_DIR"] = "./test_util/"
+
+import pytest
+
+from unittest.mock import MagicMock, patch
+
+import ocs
+from ocs.ocs_client import OCSReply
+from sorunlib import wiregrid
+
+from util import create_session
+
+
+def create_acu_client(az, el, boresight):
+    """Create an ACU client with mock monitor Process session.data.
+
+    Args:
+        az (float): Azimuth position.
+        el (float): Elevation position.
+        boresight (float): Boresight position.
+
+    """
+    acu_client = MagicMock()
+    session = create_session('monitor')
+    session.data = {'StatusDetailed': {'Azimuth current position': az,
+                                       'Elevation current position': el,
+                                       'Boresight current position': boresight}}
+    reply = OCSReply(ocs.OK, 'msg', session.encoded())
+    acu_client.monitor.status = MagicMock(return_value=reply)
+
+    return acu_client
+
+
+def create_labjack_client():
+    """Create a labjack client with mock acq Process session.data."""
+    client = MagicMock()
+    session = create_session('acq')
+    session.data = {
+        "block_name": "sens",
+        "data": {
+            "AIN0": 23.0,
+            "AIN1": 20.0,
+            "AIN2": 30.0,
+        },
+        "timestamp": time.time()
+    }
+    session.set_status('running')
+    reply = OCSReply(ocs.OK, 'msg', session.encoded())
+    client.acq.status = MagicMock(return_value=reply)
+
+    return client
+
+
+def create_actuator_client(motor):
+    """Create an actuator client with mock acq Process session.data.
+
+    Args:
+        motor (int): Motor state, 0 is off, 1 is on.
+
+    """
+    client = MagicMock()
+    session = create_session('acq')
+    session.data = {'fields': {'motor': motor},
+                    'timestamp': time.time()}
+    session.set_status('running')
+    reply = OCSReply(ocs.OK, 'msg', session.encoded())
+    client.acq.status = MagicMock(return_value=reply)
+
+    return client
+
+
+def create_kikusui_client():
+    """Create a kikusui client with mock IV_acq Process session.data."""
+    client = MagicMock()
+    session = create_session('IV_acq')
+    session.data = {
+        'fields': {
+            'kikusui': {
+                'volt': 12.0,
+                'curr': 3.0,
+                'voltset': 12.0,
+                'currset': 3.0,
+                'status': 1,
+            }
+        },
+        'timestamp': time.time(),
+    }
+    session.set_status('running')
+    reply = OCSReply(ocs.OK, 'msg', session.encoded())
+    client.IV_acq.status = MagicMock(return_value=reply)
+
+    return client
+
+
+def create_encoder_client():
+    """Create an encoder client with mock acq Process session.data."""
+    client = MagicMock()
+    session = create_session('acq')
+    session.data = {
+        'fields': {
+            'encoder_data': {'last_updated': time.time()},
+        },
+        'timestamp': time.time(),
+    }
+    session.set_status('running')
+    reply = OCSReply(ocs.OK, 'msg', session.encoded())
+    client.acq.status = MagicMock(return_value=reply)
+
+    return client
+
+
+def mocked_clients():
+    clients = {'acu': MagicMock(),
+               'smurf': [MagicMock(), MagicMock(), MagicMock()],
+               'wiregrid': {'actuator': MagicMock(),
+                            'encoder': MagicMock(),
+                            'kikusui': MagicMock(),
+                            'labjack': MagicMock()}}
+
+    return clients
+
+
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+def test_insert():
+    wiregrid.insert()
+    wiregrid.run.CLIENTS['wiregrid']['actuator'].insert.assert_called_with()
+
+
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+def test_insert_failed():
+    mocked_response = OCSReply(
+        0, 'msg', {'success': False, 'op_name': 'insert'})
+    wiregrid.run.CLIENTS['wiregrid']['actuator'].insert.side_effect = [mocked_response]
+    with pytest.raises(RuntimeError):
+        wiregrid.insert()
+
+
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+def test_eject():
+    wiregrid.eject()
+    wiregrid.run.CLIENTS['wiregrid']['actuator'].eject.assert_called_with()
+
+
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+def test_eject_failed():
+    mocked_response = OCSReply(
+        0, 'msg', {'success': False, 'op_name': 'eject'})
+    wiregrid.run.CLIENTS['wiregrid']['actuator'].eject.side_effect = [mocked_response]
+    with pytest.raises(RuntimeError):
+        wiregrid.eject()
+
+
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+@patch('sorunlib.wiregrid.time.sleep', MagicMock())
+def test_rotate_continuous():
+    wiregrid.rotate(continuous=True)
+    wiregrid.run.CLIENTS['wiregrid']['kikusui'].set_v.assert_called_once_with(volt=12)
+    wiregrid.run.CLIENTS['wiregrid']['kikusui'].set_c.assert_called_once_with(current=3.0)
+    wiregrid.run.CLIENTS['wiregrid']['kikusui'].set_on.assert_called_once()
+    wiregrid.run.CLIENTS['wiregrid']['kikusui'].set_off.assert_called_once()
+
+
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+@patch('sorunlib.wiregrid.time.sleep', MagicMock())
+def test_rotate_stepwise():
+    wiregrid.rotate(continuous=False)
+    wiregrid.run.CLIENTS['wiregrid']['kikusui'].set_v.assert_called_once_with(volt=12)
+    wiregrid.run.CLIENTS['wiregrid']['kikusui'].set_c.assert_called_once_with(current=2.4)
+    wiregrid.run.CLIENTS['wiregrid']['kikusui'].stepwise_rotation.assert_called_once_with(num_laps=1, stopped_time=10)
+
+
+def test__verify_temp_response():
+    session = create_session('test')
+    session.data = {"data": {"TEST": 2}}
+    reply = OCSReply(ocs.OK, 'msg', session.encoded())
+    wiregrid._verify_temp_response(reply, 'TEST', 0)
+
+
+def test__verify_temp_response_invalid():
+    session = create_session('test')
+    session.data = {"data": {"TEST": -10}}
+    reply = OCSReply(ocs.OK, 'msg', session.encoded())
+    with pytest.raises(RuntimeError):
+        wiregrid._verify_temp_response(reply, 'TEST', 0)
+
+
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+def test__check_temperature_sensors():
+    wiregrid.run.CLIENTS['wiregrid']['labjack'] = create_labjack_client()
+    wiregrid._check_temperature_sensors()
+    wiregrid.run.CLIENTS['wiregrid']['labjack'].acq.status.assert_called_once()
+
+
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+def test__check_telescope_position():
+    wiregrid.run.CLIENTS['acu'] = create_acu_client(180, 50, 0)
+    wiregrid._check_telescope_position()
+    wiregrid.run.CLIENTS['acu'].monitor.status.assert_called_once()
+
+
+@pytest.mark.parametrize('el,boresight', [(40, 0), (50, 10)])
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+def test__check_telescope_position_invalid(el, boresight):
+    wiregrid.run.CLIENTS['acu'] = create_acu_client(180, el, boresight)
+    with pytest.raises(RuntimeError):
+        wiregrid._check_telescope_position()
+    wiregrid.run.CLIENTS['acu'].monitor.status.assert_called_once()
+
+
+@pytest.mark.parametrize('motor', [(0), (1)])
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+def test__check_motor_on(motor):
+    wiregrid.run.CLIENTS['wiregrid']['actuator'] = create_actuator_client(motor=motor)
+    wiregrid._check_motor_on()
+    if motor == 1:
+        wiregrid.run.CLIENTS['wiregrid']['actuator'].acq.status.assert_called_once()
+        wiregrid.run.CLIENTS['wiregrid']['actuator'].motor_on.assert_not_called()
+    elif motor == 0:
+        wiregrid.run.CLIENTS['wiregrid']['actuator'].acq.status.assert_called_once()
+        wiregrid.run.CLIENTS['wiregrid']['actuator'].motor_on.assert_called_once()
+
+
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+def test__check_motor_on_invalid_state():
+    wiregrid.run.CLIENTS['wiregrid']['actuator'] = create_actuator_client(motor=3)
+    with pytest.raises(RuntimeError):
+        wiregrid._check_motor_on()
+    wiregrid.run.CLIENTS['wiregrid']['actuator'].acq.status.assert_called_once()
+
+
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+def test__check_agents_online():
+    wiregrid.run.CLIENTS['wiregrid']['actuator'] = create_actuator_client(motor=1)
+    wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
+    wiregrid.run.CLIENTS['wiregrid']['encoder'] = create_encoder_client()
+    wiregrid.run.CLIENTS['wiregrid']['labjack'] = create_labjack_client()
+    wiregrid._check_agents_online()
+    wiregrid.run.CLIENTS['wiregrid']['actuator'].acq.status.assert_called_once()
+    wiregrid.run.CLIENTS['wiregrid']['kikusui'].IV_acq.status.assert_called_once()
+    wiregrid.run.CLIENTS['wiregrid']['encoder'].acq.status.assert_called()
+    wiregrid.run.CLIENTS['wiregrid']['labjack'].acq.status.assert_called_once()
+
+
+@pytest.mark.parametrize('continuous', [(True), (False)])
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+@patch('sorunlib.wiregrid.time.sleep', MagicMock())
+def test_calibrate_stepwise(continuous):
+    # Setup all mock clients
+    wiregrid.run.CLIENTS['acu'] = create_acu_client(180, 50, 0)
+    wiregrid.run.CLIENTS['wiregrid']['actuator'] = create_actuator_client(motor=1)
+    wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
+    wiregrid.run.CLIENTS['wiregrid']['encoder'] = create_encoder_client()
+    wiregrid.run.CLIENTS['wiregrid']['labjack'] = create_labjack_client()
+
+    wiregrid.calibrate(continuous=continuous)
+    # All other internal functions tested separately, just make sure smurf
+    # stream is run
+    for client in wiregrid.run.CLIENTS['smurf']:
+        client.stream.start.assert_called()
+        client.stream.stop.assert_called()
+
+
+def test__check_process_data_stale_data():
+    with pytest.raises(RuntimeError):
+        stale_time = time.time() - wiregrid.AGENT_TIMEDIFF_THRESHOLD
+        wiregrid._check_process_data('test process', stale_time)


### PR DESCRIPTION
This PR creates the wiregrid calibration module, allowing for running a wiregrid calibration with the `run.wiregrid.calibrate()` command.

A few other commands are included, mostly to facilitate debugging, as they allow for command over individual actions taken during the `calibrate()` function -- `eject()`, `insert()`, and `rotate()`.

I split most of the new, unrelated, features out to separate PRs (see #104 and #103), but one thing I didn't split out was the addition of `check_running()`. I don't think I like the way I implemented this, but I don't want it to hold up getting the wiregrid module out, so I'll probably change that later.

Resolves #97.