### PR TITLE
Create sorunlib yaml config file

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,51 @@
+Configuration
+=============
+
+sorunlib tries to automatically determine as much about the OCS network as it
+can, however some things still require configuration. This page details the
+sorunlib configuration file.
+
+.. note::
+    This format is still under development and might change. Check back here if
+    in doubt of formatting.
+
+Example
+-------
+
+A full configuration file example with comments is shown here:
+
+.. code-block:: yaml
+
+    ---
+    # sorunlib configuration
+
+    # agents
+    # sorunlib automatically detects unique agents on the OCS network, so only
+    # non-unique agents need to be specified here.
+
+    # ocs registry agent
+    registry: 'registry'
+
+Configuration Selection
+-----------------------
+
+Select the configuration file to load by setting the ``SORUNLIB_CONFIG``
+environment variable:
+
+.. code-block:: bash
+
+    $ export SORUNLIB_CONFIG=/path/to/sorunlib/config.yaml
+
+In practice, sorunlib is typically run within a Docker container, so it's quite
+natural to set this in a compose file. The following example uses the
+``so-daq-sequencer`` image:
+
+.. code-block:: yaml
+
+    sequencer-backend:
+      image: ghcr.io/simonsobs/so-daq-sequencer:latest
+      restart: always
+      container_name: sequencer-backend
+      environment:
+        - OCS_CONFIG_DIR=/path/to/ocs/config/
+        - SORUNLIB_CONFIG=/path/to/sorunlib/config.yaml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ platform.
    :caption: Documentation
 
    design
+   configuration
 
 .. toctree::
    :maxdepth: 2

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         'ocs==0.10.3',
+        'pyyaml',
     ],
     extras_require={
         "tests": ["pytest>=7.0.0", "pytest-cov>=3.0.0"],

--- a/src/sorunlib/config.py
+++ b/src/sorunlib/config.py
@@ -1,0 +1,20 @@
+import os
+import yaml
+
+
+def load_config(filename=None):
+    """Load sorunlib config file, using SORUNLIB_CONFIG by default.
+
+    Args:
+        filename (str): Path to sorunlib config file
+
+    Returns:
+        dict
+
+    """
+    if filename is None:
+        assert (os.getenv('SORUNLIB_CONFIG') is not None)
+        filename = os.getenv('SORUNLIB_CONFIG')
+
+    with open(filename, 'rb') as f:
+        return yaml.safe_load(f)

--- a/src/sorunlib/util.py
+++ b/src/sorunlib/util.py
@@ -1,5 +1,7 @@
 import os
 
+from sorunlib.config import load_config
+
 from ocs import site_config
 from ocs.ocs_client import OCSClient
 
@@ -56,23 +58,21 @@ def _find_instances(agent_class, host=None, config=None):
     return instances
 
 
-def _find_active_instances(agent_class, config=None):
+def _find_active_instances(agent_class):
     """Find all instances of an Agent Class currently online, based on the
     Agents known by the registry.
 
     Args:
         agent_class (str): Agent Class name to search for, must match Agent
             Class defined by an OCS Agent (and thus also defined in the SCF.)
-        config (str): Path to the OCS Site Config File. If None the default
-            file in OCS_CONFIG_DIR will be used.
 
     Returns:
         list: List of instance-id's matching the given agent_class.
 
     """
-    cfg = _load_site_config(config)
+    cfg = load_config()
 
-    reg_client = OCSClient(cfg.hub.data['registry_address'])
+    reg_client = OCSClient(cfg['registry'])
     _, _, session = reg_client.main.status()
 
     instances = []
@@ -112,8 +112,8 @@ def create_clients(config=None, test_mode=False):
     else:
         smurf_agent_class = 'PysmurfController'
 
-    acu_id = _find_active_instances('ACUAgent', config=config)
-    smurf_ids = _find_active_instances(smurf_agent_class, config=config)
+    acu_id = _find_active_instances('ACUAgent')
+    smurf_ids = _find_active_instances(smurf_agent_class)
 
     if acu_id:
         acu_client = OCSClient(acu_id[0])

--- a/tests/data/example_config.yaml
+++ b/tests/data/example_config.yaml
@@ -1,0 +1,2 @@
+---
+registry: 'registry'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,15 @@
+import os
+os.environ["OCS_CONFIG_DIR"] = "./test_util/"
+os.environ["SORUNLIB_CONFIG"] = "./data/example_config.yaml"
+
+from sorunlib.config import load_config
+
+
+def test_load_config():
+    cfg = load_config("./data/example_config.yaml")
+    assert cfg == {'registry': 'registry'}
+
+
+def test_load_config_from_env():
+    cfg = load_config()
+    assert cfg == {'registry': 'registry'}


### PR DESCRIPTION
This PR establishes the basis for the sorunlib configuration file. This is a simple YAML file that will be used for configuring aspects that sorunlib can't otherwise automatically determine.

The first place this has cropped up in practice is in defining which agents to command for the wiregrid, but it'll also soon be used for PID control of the focal-plane. This first pass at a config file only contains the ocs agent registry instance-id. The config file will be extended from here in other PRs.

Resolves #98.