### PR TITLE
Add error handling to client instantiation

### DIFF
--- a/src/sorunlib/util.py
+++ b/src/sorunlib/util.py
@@ -67,7 +67,8 @@ def _find_active_instances(agent_class):
             Class defined by an OCS Agent (and thus also defined in the SCF.)
 
     Returns:
-        list: List of instance-id's matching the given agent_class.
+        str or list: List of instance-id's matching the given agent_class. If
+            the list is of length 1, just return the only instance-id.
 
     """
     cfg = load_config()
@@ -83,6 +84,9 @@ def _find_active_instances(agent_class):
         if entry['agent_class'] == agent_class:
             instance_id = entry['agent_address'].split('.')[-1]
             instances.append(instance_id)
+
+    if len(instances) == 1:
+        return instances[0]
 
     return instances
 
@@ -116,7 +120,7 @@ def create_clients(config=None, test_mode=False):
     smurf_ids = _find_active_instances(smurf_agent_class)
 
     if acu_id:
-        acu_client = OCSClient(acu_id[0])
+        acu_client = OCSClient(acu_id)
         clients['acu'] = acu_client
 
     # Always create smurf client list, even if empty

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,78 +7,85 @@ from sorunlib import util
 os.environ["OCS_CONFIG_DIR"] = "./test_util/"
 
 
-def mock_registry_client(*args, **kwargs):
-    """Mock out the client connection to the registry. Returning an example of
-    the session object that is inspected to find agent instances on the network.
+# I think this could be generalized with the Mock 'spec' argument, building an
+# object that mocks a given Agent's API, but I'm not totally sure we need that
+# yet, or how to make it so a different spec is loaded depending on which agent
+# the client is for.
+def create_mock_ocsclient(session):
+    def mock_client(*args, **kwargs):
+        client = MagicMock()
+        client.main.status = MagicMock(return_value=(None, None, session))
+        return client
 
-    """
-    client = MagicMock()
-    session_dict = {'session_id': 0,
-                    'op_name': 'main',
-                    'op_code': 3,
-                    'status': 'running',
-                    'success': None,
-                    'start_time': 1669919099.7585046,
-                    'end_time': None,
-                    'data': {
-                        'observatory.smurf-file-emulator-5': {
-                            'expired': False,
-                            'time_expired': None,
-                            'last_updated': 1669935108.8366735,
-                            'op_codes': {
-                                'uxm_setup': 1,
-                                'uxm_relock': 1,
-                                'take_iv': 1,
-                                'take_bias_steps': 1,
-                                'take_bgmap': 1,
-                                'bias_dets': 1,
-                                'take_noise': 1,
-                                'stream': 1},
-                            'agent_class': 'SmurfFileEmulator',
-                            'agent_address': 'observatory.smurf-file-emulator-5'},
-                        'observatory.smurf-file-emulator-7': {
-                            'expired': False,
-                            'time_expired': None,
-                            'last_updated': 1669935108.989246,
-                            'op_codes': {
-                                'uxm_setup': 1,
-                                'uxm_relock': 1,
-                                'take_iv': 1,
-                                'take_bias_steps': 1,
-                                'take_bgmap': 1,
-                                'bias_dets': 1,
-                                'take_noise': 1,
-                                'stream': 1},
-                            'agent_class': 'SmurfFileEmulator',
-                            'agent_address': 'observatory.smurf-file-emulator-7'},
-                        'observatory.fake-data-1': {
-                            'expired': True,
-                            'time_expired': None,
-                            'last_updated': 1669935108.989246,
-                            'op_codes': {
-                                'acq': 3,
-                                'count': 3,
-                                'set_heartbeat': 1,
-                                'delay_task': 1},
-                            'agent_class': 'FakeDataAgent',
-                            'agent_address': 'observatory.fake-data-1'},
-                        'observatory.acu-sat1': {
-                            'expired': False,
-                            'time_expired': None,
-                            'last_updated': 1669997169.469505,
-                            'op_codes': {
-                                'monitor': 3,
-                                'broadcast': 3,
-                                'generate_scan': 1,
-                                'go_to': 1,
-                                'constant_velocity_scan': 1,
-                                'fromfile_scan': 1,
-                                'set_boresight': 1,
-                                'stop_and_clear': 1},
-                            'agent_class': 'ACUAgent',
-                            'agent_address': 'observatory.acu-sat1'}}}
-    client.main.status = MagicMock(return_value=(None, None, session_dict))
-    return client
+    return mock_client
+
+
+reg_session = {'session_id': 0,
+               'op_name': 'main',
+               'op_code': 3,
+               'status': 'running',
+               'success': None,
+               'start_time': 1669919099.7585046,
+               'end_time': None,
+               'data': {
+                   'observatory.smurf-file-emulator-5': {
+                       'expired': False,
+                       'time_expired': None,
+                       'last_updated': 1669935108.8366735,
+                       'op_codes': {
+                           'uxm_setup': 1,
+                           'uxm_relock': 1,
+                           'take_iv': 1,
+                           'take_bias_steps': 1,
+                           'take_bgmap': 1,
+                           'bias_dets': 1,
+                           'take_noise': 1,
+                           'stream': 1},
+                       'agent_class': 'SmurfFileEmulator',
+                       'agent_address': 'observatory.smurf-file-emulator-5'},
+                   'observatory.smurf-file-emulator-7': {
+                       'expired': False,
+                       'time_expired': None,
+                       'last_updated': 1669935108.989246,
+                       'op_codes': {
+                           'uxm_setup': 1,
+                           'uxm_relock': 1,
+                           'take_iv': 1,
+                           'take_bias_steps': 1,
+                           'take_bgmap': 1,
+                           'bias_dets': 1,
+                           'take_noise': 1,
+                           'stream': 1},
+                       'agent_class': 'SmurfFileEmulator',
+                       'agent_address': 'observatory.smurf-file-emulator-7'},
+                   'observatory.fake-data-1': {
+                       'expired': True,
+                       'time_expired': None,
+                       'last_updated': 1669935108.989246,
+                       'op_codes': {
+                           'acq': 3,
+                           'count': 3,
+                           'set_heartbeat': 1,
+                           'delay_task': 1},
+                       'agent_class': 'FakeDataAgent',
+                       'agent_address': 'observatory.fake-data-1'},
+                   'observatory.acu-sat1': {
+                       'expired': False,
+                       'time_expired': None,
+                       'last_updated': 1669997169.469505,
+                       'op_codes': {
+                           'monitor': 3,
+                           'broadcast': 3,
+                           'generate_scan': 1,
+                           'go_to': 1,
+                           'constant_velocity_scan': 1,
+                           'fromfile_scan': 1,
+                           'set_boresight': 1,
+                           'stop_and_clear': 1},
+                       'agent_class': 'ACUAgent',
+                       'agent_address': 'observatory.acu-sat1'}}}
+
+mock_registry_client = create_mock_ocsclient(reg_session)
 
 
 def test_load_site_config():

--- a/tests/test_util/default.yaml
+++ b/tests/test_util/default.yaml
@@ -3,7 +3,7 @@ hub:
   wamp_http: http://localhost:8001/call
   wamp_realm: test_realm
   address_root: observatory
-  registry_address: observatory.registry
+  registry_address: registry
 
 hosts:
     localhost: {


### PR DESCRIPTION
This breaks out some of the `util.py` work from #99, mostly to do with improving the error handling when instantiating the clients.