### PR TITLE
Refactor how SMuRF operations are called

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'pyyaml',
     ],
     extras_require={
-        "tests": ["pytest>=7.0.0", "pytest-cov>=3.0.0"],
+        "tests": ["pytest>=7.0.0", "pytest-cov>=3.0.0", "pytest-mock>=3.12.0"],
         "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=1.1.1"],
     },
 )

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -17,6 +17,40 @@ def _wait_for_cryo(time_):
     time.sleep(wait)
 
 
+def _run_op(operation, concurrent, settling_time, **kwargs):
+    """Run operation across all active SMuRF controllers.
+
+    Additional kwargs are passed directly to the ``.start()`` call.
+
+    Args:
+        operation (str): Operation name.
+        concurrent (bool, optional): A bool which determines how the operation
+            is run across the active SMuRF controllers. It runs in parallel if
+            True, and in series if False.
+        settling_time (float, optional):
+            Time in seconds to wait between operation runs across the active
+            SMuRF controllers if *not* running concurrently. If running
+            concurrently this is ignored. If None, defaults to a fixed wait
+            time of 120 seconds.
+
+    """
+    for smurf in run.CLIENTS['smurf']:
+        op = smurf.__getattribute__(operation)
+        op.start(**kwargs)
+        if not concurrent:
+            resp = op.wait()
+            check_response(smurf, resp)
+
+            # Allow cryo to settle
+            _wait_for_cryo(settling_time)
+
+    if concurrent:
+        for smurf in run.CLIENTS['smurf']:
+            op = smurf.__getattribute__(operation)
+            resp = op.wait()
+            check_response(smurf, resp)
+
+
 def set_targets(targets):
     """Set the target pysmurf-controller Agents that sorunlib will command.
 
@@ -53,19 +87,10 @@ def bias_step(tag=None, concurrent=True, settling_time=None):
             time of 120 seconds.
 
     """
-    for smurf in run.CLIENTS['smurf']:
-        smurf.take_bias_steps.start(tag=tag)
-        if not concurrent:
-            resp = smurf.take_bias_steps.wait()
-            check_response(smurf, resp)
-
-            # Allow cryo to settle
-            _wait_for_cryo(settling_time)
-
-    if concurrent:
-        for smurf in run.CLIENTS['smurf']:
-            resp = smurf.take_bias_steps.wait()
-            check_response(smurf, resp)
+    _run_op('take_bias_steps',
+            concurrent=concurrent,
+            settling_time=settling_time,
+            tag=tag)
 
 
 def iv_curve(tag=None, concurrent=True, settling_time=None):
@@ -84,19 +109,10 @@ def iv_curve(tag=None, concurrent=True, settling_time=None):
             time of 120 seconds.
 
     """
-    for smurf in run.CLIENTS['smurf']:
-        smurf.take_iv.start(tag=tag)
-        if not concurrent:
-            resp = smurf.take_iv.wait()
-            check_response(smurf, resp)
-
-            # Allow cryo to settle
-            _wait_for_cryo(settling_time)
-
-    if concurrent:
-        for smurf in run.CLIENTS['smurf']:
-            resp = smurf.take_iv.wait()
-            check_response(smurf, resp)
+    _run_op('take_iv',
+            concurrent=concurrent,
+            settling_time=settling_time,
+            tag=tag)
 
 
 def uxm_setup(concurrent=True, settling_time=0):
@@ -112,19 +128,9 @@ def uxm_setup(concurrent=True, settling_time=0):
             concurrently this is ignored. Defaults to 0 seconds.
 
     """
-    for smurf in run.CLIENTS['smurf']:
-        smurf.uxm_setup.start()
-        if not concurrent:
-            resp = smurf.uxm_setup.wait()
-            check_response(smurf, resp)
-
-            # Allow cryo to settle
-            time.sleep(settling_time)
-
-    if concurrent:
-        for smurf in run.CLIENTS['smurf']:
-            resp = smurf.uxm_setup.wait()
-            check_response(smurf, resp)
+    _run_op('uxm_setup',
+            concurrent=concurrent,
+            settling_time=settling_time)
 
 
 def uxm_relock(test_mode=False, concurrent=True, settling_time=0):
@@ -142,23 +148,15 @@ def uxm_relock(test_mode=False, concurrent=True, settling_time=0):
             concurrently this is ignored. Defaults to 0 seconds.
 
     """
-    for smurf in run.CLIENTS['smurf']:
-        if test_mode:
-            smurf.uxm_relock.start(test_mode=test_mode)
-        else:
-            smurf.uxm_relock.start()
-
-        if not concurrent:
-            resp = smurf.uxm_relock.wait()
-            check_response(smurf, resp)
-
-            # Allow cryo to settle
-            time.sleep(settling_time)
-
-    if concurrent:
-        for smurf in run.CLIENTS['smurf']:
-            resp = smurf.uxm_relock.wait()
-            check_response(smurf, resp)
+    if test_mode:
+        _run_op('uxm_relock',
+                concurrent=concurrent,
+                settling_time=settling_time,
+                test_mode=test_mode)
+    else:
+        _run_op('uxm_relock',
+                concurrent=concurrent,
+                settling_time=settling_time)
 
 
 def bias_dets(concurrent=True, settling_time=0):
@@ -174,19 +172,9 @@ def bias_dets(concurrent=True, settling_time=0):
             concurrently this is ignored. Defaults to 0 seconds.
 
     """
-    for smurf in run.CLIENTS['smurf']:
-        smurf.bias_dets.start()
-        if not concurrent:
-            resp = smurf.bias_dets.wait()
-            check_response(smurf, resp)
-
-            # Allow cryo to settle
-            time.sleep(settling_time)
-
-    if concurrent:
-        for smurf in run.CLIENTS['smurf']:
-            resp = smurf.bias_dets.wait()
-            check_response(smurf, resp)
+    _run_op('bias_dets',
+            concurrent=concurrent,
+            settling_time=settling_time)
 
 
 def set_biases(bias, bias_group=None, concurrent=True, settling_time=0):
@@ -209,19 +197,11 @@ def set_biases(bias, bias_group=None, concurrent=True, settling_time=0):
             concurrently this is ignored. Defaults to 0 seconds.
 
     """
-    for smurf in run.CLIENTS['smurf']:
-        smurf.set_biases.start(bias=bias, bg=bias_group)
-        if not concurrent:
-            resp = smurf.set_biases.wait()
-            check_response(smurf, resp)
-
-            # Allow cryo to settle
-            time.sleep(settling_time)
-
-    if concurrent:
-        for smurf in run.CLIENTS['smurf']:
-            resp = smurf.set_biases.wait()
-            check_response(smurf, resp)
+    _run_op('set_biases',
+            concurrent=concurrent,
+            settling_time=settling_time,
+            bias=bias,
+            bg=bias_group)
 
 
 def zero_biases(bias_group=None, concurrent=True, settling_time=0):
@@ -240,19 +220,10 @@ def zero_biases(bias_group=None, concurrent=True, settling_time=0):
             concurrently this is ignored. Defaults to 0 seconds.
 
     """
-    for smurf in run.CLIENTS['smurf']:
-        smurf.zero_biases.start(bg=bias_group)
-        if not concurrent:
-            resp = smurf.zero_biases.wait()
-            check_response(smurf, resp)
-
-            # Allow cryo to settle
-            time.sleep(settling_time)
-
-    if concurrent:
-        for smurf in run.CLIENTS['smurf']:
-            resp = smurf.zero_biases.wait()
-            check_response(smurf, resp)
+    _run_op('zero_biases',
+            concurrent=concurrent,
+            settling_time=settling_time,
+            bg=bias_group)
 
 
 def take_bgmap(tag=None, concurrent=True, settling_time=0):
@@ -270,19 +241,10 @@ def take_bgmap(tag=None, concurrent=True, settling_time=0):
             concurrently this is ignored. Defaults to 0 seconds.
 
     """
-    for smurf in run.CLIENTS['smurf']:
-        smurf.take_bgmap.start(tag=tag)
-        if not concurrent:
-            resp = smurf.take_bgmap.wait()
-            check_response(smurf, resp)
-
-            # Allow cryo to settle
-            time.sleep(settling_time)
-
-    if concurrent:
-        for smurf in run.CLIENTS['smurf']:
-            resp = smurf.take_bgmap.wait()
-            check_response(smurf, resp)
+    _run_op('take_bgmap',
+            concurrent=concurrent,
+            settling_time=settling_time,
+            tag=tag)
 
 
 def take_noise(tag=None, concurrent=True, settling_time=0):
@@ -300,19 +262,10 @@ def take_noise(tag=None, concurrent=True, settling_time=0):
             concurrently this is ignored. Defaults to 0 seconds.
 
     """
-    for smurf in run.CLIENTS['smurf']:
-        smurf.take_noise.start(tag=tag)
-        if not concurrent:
-            resp = smurf.take_noise.wait()
-            check_response(smurf, resp)
-
-            # Allow cryo to settle
-            time.sleep(settling_time)
-
-    if concurrent:
-        for smurf in run.CLIENTS['smurf']:
-            resp = smurf.take_noise.wait()
-            check_response(smurf, resp)
+    _run_op('take_noise',
+            concurrent=concurrent,
+            settling_time=settling_time,
+            tag=tag)
 
 
 def stream(state, tag=None, subtype=None):

--- a/tests/integration/test_example_script.py
+++ b/tests/integration/test_example_script.py
@@ -1,27 +1,9 @@
 import datetime as dt
 from unittest.mock import MagicMock, patch
 
+from util import mocked_clients
+
 from sorunlib import *
-
-# should import from common place, duplicating construction in smurf testing module
-
-
-def _mock_smurf_client(instance_id):
-    smurf = MagicMock()
-    smurf.instance_id = instance_id
-    smurf.take_bias_steps = MagicMock()
-    smurf.take_iv = MagicMock()
-
-    return smurf
-
-
-def mocked_clients(test_mode):
-    smurf_ids = ['smurf1', 'smurf2', 'smurf3']
-    smurfs = [_mock_smurf_client(id_) for id_ in smurf_ids]
-    clients = {'acu': MagicMock(),
-               'smurf': smurfs}
-
-    return clients
 
 
 # patch out time.sleep so we don't actually wait during testing

--- a/tests/integration/test_example_script.py
+++ b/tests/integration/test_example_script.py
@@ -3,10 +3,23 @@ from unittest.mock import MagicMock, patch
 
 from sorunlib import *
 
+# should import from common place, duplicating construction in smurf testing module
+
+
+def _mock_smurf_client(instance_id):
+    smurf = MagicMock()
+    smurf.instance_id = instance_id
+    smurf.take_bias_steps = MagicMock()
+    smurf.take_iv = MagicMock()
+
+    return smurf
+
 
 def mocked_clients(test_mode):
+    smurf_ids = ['smurf1', 'smurf2', 'smurf3']
+    smurfs = [_mock_smurf_client(id_) for id_ in smurf_ids]
     clients = {'acu': MagicMock(),
-               'smurf': [MagicMock(), MagicMock(), MagicMock()]}
+               'smurf': smurfs}
 
     return clients
 

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -49,7 +49,7 @@ def test_bias_step(concurrent):
     smurf.run.initialize(test_mode=True)
     smurf.bias_step(concurrent=concurrent, settling_time=10)
     for client in smurf.run.CLIENTS['smurf']:
-        client.take_bias_steps.start.assert_called_once()
+        client.take_bias_steps.start.assert_called_with(tag=None)
 
 
 @patch('sorunlib.smurf.time.sleep', MagicMock())
@@ -59,7 +59,7 @@ def test_iv_curve(concurrent):
     smurf.run.initialize(test_mode=True)
     smurf.iv_curve(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
-        client.take_iv.start.assert_called_once()
+        client.take_iv.start.assert_called_with(tag=None)
 
 
 @patch('sorunlib.smurf.time.sleep', MagicMock())
@@ -110,7 +110,7 @@ def test_set_biases(concurrent):
     smurf.run.initialize(test_mode=True)
     smurf.set_biases(bias=1, bias_group=None, concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
-        client.set_biases.start.assert_called_once()
+        client.set_biases.start.assert_called_with(bias=1, bg=None)
 
 
 @patch('sorunlib.create_clients', mocked_clients)
@@ -119,7 +119,7 @@ def test_zero_biases(concurrent):
     smurf.run.initialize(test_mode=True)
     smurf.zero_biases(bias_group=None, concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
-        client.zero_biases.start.assert_called_once()
+        client.zero_biases.start.assert_called_with(bg=None)
 
 
 @patch('sorunlib.create_clients', mocked_clients)
@@ -128,7 +128,7 @@ def test_bgmap(concurrent):
     smurf.run.initialize(test_mode=True)
     smurf.take_bgmap(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
-        client.take_bgmap.start.assert_called_once()
+        client.take_bgmap.start.assert_called_with(tag=None)
 
 
 @patch('sorunlib.create_clients', mocked_clients)
@@ -137,7 +137,7 @@ def test_take_noise(concurrent):
     smurf.run.initialize(test_mode=True)
     smurf.take_noise(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
-        client.take_noise.start.assert_called_once()
+        client.take_noise.start.assert_called_with(tag=None)
 
 
 @patch('sorunlib.create_clients', mocked_clients)

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -5,33 +5,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from util import mocked_clients
+
 from sorunlib import smurf
-
-
-def _mock_smurf_client(instance_id):
-    smurf = MagicMock()
-    smurf.instance_id = instance_id
-    smurf.take_bias_steps = MagicMock()
-    smurf.take_iv = MagicMock()
-    smurf.uxm_setup = MagicMock()
-    smurf.uxm_relock = MagicMock()
-    smurf.bias_dets = MagicMock()
-    smurf.set_biases = MagicMock()
-    smurf.zero_biases = MagicMock()
-    smurf.take_bgmap = MagicMock()
-    smurf.take_noise = MagicMock()
-
-    return smurf
-
-
-def mocked_clients(test_mode):
-    smurf_ids = ['smurf1', 'smurf2', 'smurf3']
-    smurfs = [_mock_smurf_client(id_) for id_ in smurf_ids]
-
-    clients = {'acu': MagicMock(),
-               'smurf': smurfs}
-
-    return clients
 
 
 @patch('sorunlib.create_clients', mocked_clients)

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -11,6 +11,15 @@ from sorunlib import smurf
 def _mock_smurf_client(instance_id):
     smurf = MagicMock()
     smurf.instance_id = instance_id
+    smurf.take_bias_steps = MagicMock()
+    smurf.take_iv = MagicMock()
+    smurf.uxm_setup = MagicMock()
+    smurf.uxm_relock = MagicMock()
+    smurf.bias_dets = MagicMock()
+    smurf.set_biases = MagicMock()
+    smurf.zero_biases = MagicMock()
+    smurf.take_bgmap = MagicMock()
+    smurf.take_noise = MagicMock()
 
     return smurf
 

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -10,59 +10,54 @@ from util import mocked_clients
 from sorunlib import smurf
 
 
+# Use pytest-mock plugin to patch CLIENTS on all tests
+@pytest.fixture(autouse=True)
+def patch_clients(mocker):
+    mocker.patch('sorunlib.smurf.run.CLIENTS', mocked_clients())
+
+
 @patch('sorunlib.create_clients', mocked_clients)
 def test_set_targets():
-    smurf.run.initialize(test_mode=True)
     smurf.set_targets(['smurf1'])
     assert len(smurf.run.CLIENTS['smurf']) == 1
     assert smurf.run.CLIENTS['smurf'][0].instance_id == 'smurf1'
 
 
 @patch('sorunlib.smurf.time.sleep', MagicMock())
-@patch('sorunlib.create_clients', mocked_clients)
 @pytest.mark.parametrize("concurrent", [(True), (False)])
 def test_bias_step(concurrent):
-    smurf.run.initialize(test_mode=True)
     smurf.bias_step(concurrent=concurrent, settling_time=10)
     for client in smurf.run.CLIENTS['smurf']:
         client.take_bias_steps.start.assert_called_with(tag=None)
 
 
 @patch('sorunlib.smurf.time.sleep', MagicMock())
-@patch('sorunlib.create_clients', mocked_clients)
 @pytest.mark.parametrize("concurrent", [(True), (False)])
 def test_iv_curve(concurrent):
-    smurf.run.initialize(test_mode=True)
     smurf.iv_curve(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.take_iv.start.assert_called_with(tag=None)
 
 
 @patch('sorunlib.smurf.time.sleep', MagicMock())
-@patch('sorunlib.create_clients', mocked_clients)
 @pytest.mark.parametrize("concurrent", [(True), (False)])
 def test_uxm_setup(concurrent):
-    smurf.run.initialize(test_mode=True)
     smurf.uxm_setup(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.uxm_setup.start.assert_called_once()
 
 
 @patch('sorunlib.smurf.time.sleep', MagicMock())
-@patch('sorunlib.create_clients', mocked_clients)
 @pytest.mark.parametrize("concurrent", [(True), (False)])
 def test_uxm_relock(concurrent):
-    smurf.run.initialize(test_mode=True)
     smurf.uxm_relock(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.uxm_relock.start.assert_called_once()
 
 
 @patch('sorunlib.smurf.time.sleep', MagicMock())
-@patch('sorunlib.create_clients', mocked_clients)
 @pytest.mark.parametrize("test_mode", [(True), (False)])
 def test_uxm_relock_test_mode(test_mode):
-    smurf.run.initialize(test_mode=True)  # always True
     smurf.uxm_relock(test_mode=test_mode)
     for client in smurf.run.CLIENTS['smurf']:
         if test_mode:
@@ -71,54 +66,42 @@ def test_uxm_relock_test_mode(test_mode):
             client.uxm_relock.start.assert_called_with()
 
 
-@patch('sorunlib.create_clients', mocked_clients)
 @pytest.mark.parametrize("concurrent", [(True), (False)])
 def test_bias_dets(concurrent):
-    smurf.run.initialize(test_mode=True)
     smurf.bias_dets(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.bias_dets.start.assert_called_once()
 
 
-@patch('sorunlib.create_clients', mocked_clients)
 @pytest.mark.parametrize("concurrent", [(True), (False)])
 def test_set_biases(concurrent):
-    smurf.run.initialize(test_mode=True)
     smurf.set_biases(bias=1, bias_group=None, concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.set_biases.start.assert_called_with(bias=1, bg=None)
 
 
-@patch('sorunlib.create_clients', mocked_clients)
 @pytest.mark.parametrize("concurrent", [(True), (False)])
 def test_zero_biases(concurrent):
-    smurf.run.initialize(test_mode=True)
     smurf.zero_biases(bias_group=None, concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.zero_biases.start.assert_called_with(bg=None)
 
 
-@patch('sorunlib.create_clients', mocked_clients)
 @pytest.mark.parametrize("concurrent", [(True), (False)])
 def test_bgmap(concurrent):
-    smurf.run.initialize(test_mode=True)
     smurf.take_bgmap(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.take_bgmap.start.assert_called_with(tag=None)
 
 
-@patch('sorunlib.create_clients', mocked_clients)
 @pytest.mark.parametrize("concurrent", [(True), (False)])
 def test_take_noise(concurrent):
-    smurf.run.initialize(test_mode=True)
     smurf.take_noise(concurrent=concurrent)
     for client in smurf.run.CLIENTS['smurf']:
         client.take_noise.start.assert_called_with(tag=None)
 
 
-@patch('sorunlib.create_clients', mocked_clients)
 def test_stream():
-    smurf.run.initialize(test_mode=True)
     smurf.stream(state='on')
     for client in smurf.run.CLIENTS['smurf']:
         client.stream.start.assert_called_once()

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,11 +1,45 @@
-from unittest import mock
+from unittest.mock import MagicMock
 
 from ocs.ocs_agent import OpSession
 
 
 def create_session(op_name):
     """Create an OpSession with a mocked app for testing."""
-    mock_app = mock.MagicMock()
+    mock_app = MagicMock()
     session = OpSession(1, op_name, app=mock_app)
 
     return session
+
+
+# Mocked Clients
+# This should be considered the authoritative source for mocking the CLIENTS
+# dict. Otherwise each test ends up implementing their own version of the
+# clients.
+#
+# Tests that need to interact with a client should import from here unless
+# they're testing some specific unique response from a client, like if it
+# raises an exception under certain conditions.
+def _mock_smurf_client(instance_id):
+    smurf = MagicMock()
+    smurf.instance_id = instance_id
+    smurf.take_bias_steps = MagicMock()
+    smurf.take_iv = MagicMock()
+    smurf.uxm_setup = MagicMock()
+    smurf.uxm_relock = MagicMock()
+    smurf.bias_dets = MagicMock()
+    smurf.set_biases = MagicMock()
+    smurf.zero_biases = MagicMock()
+    smurf.take_bgmap = MagicMock()
+    smurf.take_noise = MagicMock()
+
+    return smurf
+
+
+def mocked_clients(test_mode):
+    smurf_ids = ['smurf1', 'smurf2', 'smurf3']
+    smurfs = [_mock_smurf_client(id_) for id_ in smurf_ids]
+
+    clients = {'acu': MagicMock(),
+               'smurf': smurfs}
+
+    return clients

--- a/tests/util.py
+++ b/tests/util.py
@@ -35,7 +35,7 @@ def _mock_smurf_client(instance_id):
     return smurf
 
 
-def mocked_clients(test_mode):
+def mocked_clients(**kwargs):
     smurf_ids = ['smurf1', 'smurf2', 'smurf3']
     smurfs = [_mock_smurf_client(id_) for id_ in smurf_ids]
 


### PR DESCRIPTION
This PR contains the following:

1. Introduces `smurf._run_op()`, which provides a convenient way to call any given task in the pysmurf controllers. 
2. Expands the way the mocked smurf clients were constructed -- all SMuRF operations now need their own Mock object due to the construction in `smurf._run_op()`.
3. Moves the mocked clients function to `tests/util.py`, since several tests are implementing the same thing. Future tests should use this as the "one true mock".
4. Updates the `CLIENTS` list patch to patch it directly, rather than patching the `create_clients()` function (which still then requires an `initialize()` is run in every test). This matches the way the wiregrid module patches.

This is in advance of work on #94, which requires adding error handling within `_run_op()`.