### PR TITLE
Handle SMuRF operation failures

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -19,6 +19,9 @@ A full configuration file example with comments is shown here:
     ---
     # sorunlib configuration
 
+    # minimum number of SMuRFs that must be working to continue operations
+    smurf_failure_threshold: 3
+
     # agents
     # sorunlib automatically detects unique agents on the OCS network, so only
     # non-unique agents need to be specified here.

--- a/tests/data/example_config.yaml
+++ b/tests/data/example_config.yaml
@@ -1,4 +1,5 @@
 ---
+smurf_failure_threshold: 2
 registry: 'registry'
 wiregrid:
   labjack: 'wg-labjack'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,14 +4,16 @@ os.environ["SORUNLIB_CONFIG"] = "./data/example_config.yaml"
 
 from sorunlib.config import load_config
 
+CONFIG = {'smurf_failure_threshold': 2,
+          'registry': 'registry',
+          'wiregrid': {'labjack': 'wg-labjack'}}
+
 
 def test_load_config():
     cfg = load_config("./data/example_config.yaml")
-    assert cfg == {'registry': 'registry',
-                   'wiregrid': {'labjack': 'wg-labjack'}}
+    assert cfg == CONFIG
 
 
 def test_load_config_from_env():
     cfg = load_config()
-    assert cfg == {'registry': 'registry',
-                   'wiregrid': {'labjack': 'wg-labjack'}}
+    assert cfg == CONFIG


### PR DESCRIPTION
This PR adds error handling for SMuRF operations, removing any SMuRF client that fails to perform a given operation from the global `CLIENTS` list, thus removing it from receiving further commands.

To avoid removing all SMuRFs and having that go unnoticed this also introduces the `smurf_failure_threshold` configuration, which is checked after each operation to ensure we still have enough SMuRFs in operation to continue, raising an exception if we do not.

Resolves #94.