### PR TITLE
Stop SMuRF streams before stopping telescope scan

### DIFF
--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -48,11 +48,12 @@ def scan(description, stop_time, width, az_drift=0, tag=None, subtype=None):
         # Wait until stop time
         run.commands.wait_until(stop_time)
     finally:
-        # Stop motion
         print("Stopping scan.")
+        # Stop SMuRF streams
+        run.smurf.stream('off')
+
+        # Stop motion
         acu.generate_scan.stop()
         resp = acu.generate_scan.wait(timeout=OP_TIMEOUT)
         check_response(acu, resp)
-
-        # Stop SMuRF streams
-        run.smurf.stream('off')
+        print("Scan finished.")


### PR DESCRIPTION
This works around an ACU related error causing the SMuRF streams to not stop at the end of a failed scan. A temporary workaround for now.

Resolves #95.

Note that #115 still needs addressing and involves regularly checking the status of the `generate_scan` process.