### PR TITLE
Create blocking process monitor function

### DIFF
--- a/src/sorunlib/_internal.py
+++ b/src/sorunlib/_internal.py
@@ -148,8 +148,8 @@ def monitor_process(client, operation, stop_time, check_interval=10):
     ``operation`` is still running every ``check_interval`` seconds.
 
     Args:
-        client (ocs.ocs_client.OCSClient): OCS Client which returned the
-            response.
+        client (ocs.ocs_client.OCSClient): OCS Client that has the process to
+            monitor.
         operation (str): Operation name to monitor.
         stop_time (str): Time in ISO format and in UTC timezone to stop
             monitoring the process. If UTC ("+00:00") is not explicitly used in

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -1,5 +1,5 @@
 import sorunlib as run
-from sorunlib._internal import check_response, check_started
+from sorunlib._internal import check_response, check_started, monitor_process
 
 
 OP_TIMEOUT = 60
@@ -44,7 +44,7 @@ def scan(description, stop_time, width, az_drift=0, tag=None, subtype=None):
         check_started(acu, resp)
 
         # Wait until stop time
-        run.commands.wait_until(stop_time)
+        monitor_process(acu, 'generate_scan', stop_time)
     finally:
         print("Stopping scan.")
         # Stop SMuRF streams

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -17,9 +17,10 @@ from util import create_patch_clients, create_session
 patch_clients = create_patch_clients('satp')
 
 
-@patch('sorunlib.commands.time.sleep', MagicMock())
+@patch('sorunlib._internal.time.sleep', MagicMock())
 def test_scan(patch_clients):
-    target = dt.datetime.now() + dt.timedelta(seconds=1)
+    # This affects test runtime duration keep it short
+    target = dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=0.01)
     seq.scan(description='test', stop_time=target.isoformat(), width=20.)
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -63,6 +63,7 @@ def _mock_acu_client(platform_type, az=180, el=50, boresight=0):
 
     session = create_session('generate_scan', status='running')
     reply = OCSReply(ocs.OK, 'msg', session.encoded())
+    acu.generate_scan = MagicMock()
     acu.generate_scan.start = MagicMock(return_value=reply)
     acu.generate_scan.status = MagicMock(return_value=reply)
 


### PR DESCRIPTION
This PR introduces `monitor_process()`, a function that replaces the use of `run.commands.wait_until` within `seq.scan`. It accomplishes the same effect as `wait_until` -- blocking until the specified time -- and also continuously checks the status of a given process ('generate_scan', in the `seq.scan` case.) It'll raise an exception if the process fails, ending the current schedule.

This can generally be used on any process, however since it is blocking it can't monitor processes that need to run during a scan.

Resolves #115.
Resolves #113.