### PR TITLE
Make wiregrid agent config optional

### DIFF
--- a/src/sorunlib/util.py
+++ b/src/sorunlib/util.py
@@ -99,6 +99,9 @@ def _find_active_instances(agent_class):
 
 def _try_client(instanceid):
     """User in place of OCSClient to handle common exceptions."""
+    if not instanceid:
+        return
+
     try:
         client = OCSClient(instanceid)
     except ControlClientError as e:

--- a/src/sorunlib/util.py
+++ b/src/sorunlib/util.py
@@ -138,7 +138,10 @@ def _create_wiregrid_clients(config=None, sorunlib_config=None):
     kikusui = _find_active_instances('WiregridKikusuiAgent')
 
     cfg = load_config(filename=sorunlib_config)
-    labjack = cfg['wiregrid']['labjack']
+    try:
+        labjack = cfg['wiregrid']['labjack']
+    except KeyError:
+        labjack = None
 
     clients = {'actuator': _try_client(actuator),
                'encoder': _try_client(encoder),
@@ -148,12 +151,14 @@ def _create_wiregrid_clients(config=None, sorunlib_config=None):
     return clients
 
 
-def create_clients(config=None, test_mode=False):
+def create_clients(config=None, sorunlib_config=None, test_mode=False):
     """Create all clients needed for commanding a single platform.
 
     Args:
         config (str): Path to the OCS Site Config File. If None the default
             file in OCS_CONFIG_DIR will be used.
+        sorunlib_config (str): Path to sorunlib config file. If None the path
+            from environment variable SORUNLIB_CONFIG is used.
         test_mode (bool): Operate in 'test mode'. Use this to find Agents that
             are meant to stand in for real agents while testing, i.e.
             SmurfFileEmulators instead of PysmurfControllers.
@@ -188,6 +193,8 @@ def create_clients(config=None, test_mode=False):
     smurf_clients = [_try_client(x) for x in smurf_ids]
     clients['smurf'] = smurf_clients
 
-    clients['wiregrid'] = _create_wiregrid_clients(config=config)
+    clients['wiregrid'] = _create_wiregrid_clients(
+        config=config,
+        sorunlib_config=sorunlib_config)
 
     return clients

--- a/tests/data/minimal_config.yaml
+++ b/tests/data/minimal_config.yaml
@@ -1,0 +1,3 @@
+---
+smurf_failure_threshold: 2
+registry: 'registry'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -169,3 +169,15 @@ def test_create_clients_test_mode():
     assert 'smurf' in clients
     assert len(clients['smurf']) == 2
     assert 'wiregrid' in clients
+
+
+@patch('sorunlib.util.OCSClient', mock_registry_client)
+def test__create_clients_minimal_config():
+    clients = util.create_clients(sorunlib_config='./data/minimal_config.yaml')
+    assert 'acu' in clients
+    assert 'smurf' in clients
+    assert len(clients['smurf']) == 0  # since we're not in test_mode
+    # Optional configs
+    assert 'wiregrid' in clients
+    for client in clients['wiregrid'].values():
+        assert client is None


### PR DESCRIPTION
This PR includes a couple of things:
* It makes the wiregrid agent config optional, since the LAT does not have wiregrids.
* It removes the innocuous output about not being able to instantiate clients for agents that can't be found, i.e. `Could not instantiate OCSClient for '[]'.` from #120.

Resolves #120.
Resolves #125.