### PR TITLE
Fix 'AIN*' field names for Celsius reading

### DIFF
--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -174,10 +174,10 @@ def _check_temperature_sensors():
     labjack = run.CLIENTS['wiregrid']['labjack']
     resp = labjack.acq.status()
     # AIN0 > -10 C && AIN1 > -10 C (On the wiregrid)
-    _verify_temp_response(resp, 'AIN0', -10)
-    _verify_temp_response(resp, 'AIN1', -10)
+    _verify_temp_response(resp, 'AIN0C', -10)
+    _verify_temp_response(resp, 'AIN1C', -10)
     # AIN2 > 0 C (Inside the electronics enclosure for the gridloader)
-    _verify_temp_response(resp, 'AIN2', 0)
+    _verify_temp_response(resp, 'AIN2C', 0)
 
 
 # Public API

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -42,9 +42,9 @@ def create_labjack_client():
     session.data = {
         "block_name": "sens",
         "data": {
-            "AIN0": 23.0,
-            "AIN1": 20.0,
-            "AIN2": 30.0,
+            "AIN0C": 23.0,
+            "AIN1C": 20.0,
+            "AIN2C": 30.0,
         },
         "timestamp": time.time()
     }


### PR DESCRIPTION
The 'AIN*' fields need a 'C' at the end -- the two readings available are 'V' for the raw voltage the labjack is reading and 'C' for the corresponding Celsius reading.

Found this while testing the `wiregrid.calibrate()` command at the site. Tested this fix during that process as well.