### PR TITLE
Drop Python 3.7 and add 3.11 and 3.12 to support list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,15 +23,16 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: BSD License",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Astronomy",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         'ocs==0.11.0',
         'pyyaml',


### PR DESCRIPTION
Drop 3.7 since it's past end of life. Add 3.11 and 3.12 so they show up on PyPI and in the badge here.