### PR TITLE
Fix issue creating SMuRF controller client list for single controllers

### DIFF
--- a/src/sorunlib/util.py
+++ b/src/sorunlib/util.py
@@ -197,8 +197,12 @@ def create_clients(config=None, sorunlib_config=None, test_mode=False):
         hwp_client = _try_client(hwp_id)
         clients['hwp'] = hwp_client
 
-    # Always create smurf client list, even if empty
-    smurf_clients = [_try_client(x) for x in smurf_ids]
+    if isinstance(smurf_ids, str):
+        # when only a single SMuRF controller online
+        smurf_clients = [smurf_ids]
+    else:
+        # create smurf client list, even if empty
+        smurf_clients = [_try_client(x) for x in smurf_ids]
     clients['smurf'] = smurf_clients
 
     clients['wiregrid'] = _create_wiregrid_clients(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -104,8 +104,32 @@ reg_session = {'session_id': 0,
                            'stop_and_clear': 1},
                        'agent_class': 'ACUAgent',
                        'agent_address': 'observatory.acu-sat1'}}}
-
 mock_registry_client = create_mock_ocsclient(reg_session)
+
+reg_session_single_smurf = {'session_id': 0,
+                            'op_name': 'main',
+                            'op_code': 3,
+                            'status': 'running',
+                            'success': None,
+                            'start_time': 1669919099.7585046,
+                            'end_time': None,
+                            'data': {
+                                'observatory.smurf-file-emulator-5': {
+                                    'expired': False,
+                                    'time_expired': None,
+                                    'last_updated': 1669935108.8366735,
+                                    'op_codes': {
+                                        'uxm_setup': 1,
+                                        'uxm_relock': 1,
+                                        'take_iv': 1,
+                                        'take_bias_steps': 1,
+                                        'take_bgmap': 1,
+                                        'bias_dets': 1,
+                                        'take_noise': 1,
+                                        'stream': 1},
+                                    'agent_class': 'SmurfFileEmulator',
+                                    'agent_address': 'observatory.smurf-file-emulator-5'}}}
+mock_registry_client_single_smurf = create_mock_ocsclient(reg_session_single_smurf)
 
 
 class NoAgentClient:
@@ -185,6 +209,13 @@ def test_create_clients_test_mode():
     assert 'smurf' in clients
     assert len(clients['smurf']) == 2
     assert 'wiregrid' in clients
+
+
+@patch('sorunlib.util.OCSClient', mock_registry_client_single_smurf)
+def test_create_clients_test_mode_single_smurf():
+    clients = util.create_clients(test_mode=True)
+    assert 'smurf' in clients
+    assert len(clients['smurf']) == 1
 
 
 @patch('sorunlib.util.OCSClient', mock_registry_client)


### PR DESCRIPTION
This adds a check for if we've just got a single controller instance back from `_find_active_instances()`, which was resulting in the error described in #153. `_find_active_instances()` returns a single string when it only finds one of a given Agent type online, otherwise it returns a list. We were handling the instance of two or more SMuRFs and zero SMuRFs, but not one. This fixes that.

I added a whole new mock client setup to test this. There might be some way to simplify this, but I'm not too concerned at the moment. If we need to add a third mock client setup we should figure that out.

Resolves #153.