### PR TITLE
Add arguments in the `calibration()` to enable the removal of various checks

### DIFF
--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -257,19 +257,19 @@ def rotate(continuous, duration=30, num_laps=1, stopped_time=10.):
 
 
 def calibrate(continuous=False, elevation_check=True, boresight_check=True,
-        temperature_check=True):
+              temperature_check=True):
     """Run a wiregrid calibration.
 
     Args:
         continuous (bool): Calibration by continuous rotation or not.
             Default is False, in which the wiregrid rotates step-wisely.
-        boresight_check (bool): Check the boresight angle before 
+        boresight_check (bool): Check the boresight angle before
             the calibration or not
 
     """
     try:
-        _check_telescope_position(elevation_check=elevation_check, 
-                boresight_check=boresight_check)
+        _check_telescope_position(elevation_check=elevation_check,
+                                  boresight_check=boresight_check)
         _check_agents_online()
         if temperature_check:
             _check_temperature_sensors()

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -72,7 +72,7 @@ def _check_zenith():
 
 
 # Calibration Functions
-def _check_telescope_position():
+def _check_telescope_position(boresight_check=True):
     # Get current telescope position
     acu = run.CLIENTS['acu']
     resp = acu.monitor.status()
@@ -90,13 +90,14 @@ def _check_telescope_position():
         raise RuntimeError(error)
 
     # Check boresight angle
-    try:
-        assert (abs(boresight - 0) < BORESIGHT_DIFF_THRESHOLD)
-    except AssertionError:
-        error = "Telescope not at 0 deg boresight. Cannot proceed with " + \
-                f"wiregrid calibration in current position ({boresight}). " + \
-                "Aborting."
-        raise RuntimeError(error)
+    if boresight_check:
+        try:
+            assert (abs(boresight - 0) < BORESIGHT_DIFF_THRESHOLD)
+        except AssertionError:
+            error = "Telescope not at 0 deg boresight. Cannot proceed with " + \
+                    f"wiregrid calibration in current position ({boresight}). " + \
+                    "Aborting."
+            raise RuntimeError(error)
 
 
 def _configure_power(continuous):
@@ -254,16 +255,18 @@ def rotate(continuous, duration=30, num_laps=1, stopped_time=10.):
         check_response(kikusui, resp)
 
 
-def calibrate(continuous=False):
+def calibrate(continuous=False, boresight_check=True):
     """Run a wiregrid calibration.
 
     Args:
         continuous (bool): Calibration by continuous rotation or not.
             Default is False, in which the wiregrid rotates step-wisely.
+        boresight_check (bool): Check the boresight angle before 
+            the calibration or not
 
     """
     try:
-        _check_telescope_position()
+        _check_telescope_position(boresight_check=boresight_check)
         _check_agents_online()
         _check_temperature_sensors()
         _check_motor_on()

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -263,8 +263,13 @@ def calibrate(continuous=False, elevation_check=True, boresight_check=True,
     Args:
         continuous (bool): Calibration by continuous rotation or not.
             Default is False, in which the wiregrid rotates step-wisely.
-        boresight_check (bool): Check the boresight angle before
-            the calibration or not
+        elevation_check (bool): Check the elevation angle is in an appropriate
+            range before the calibration or not. Default is True.
+        boresight_check (bool): Check the boresight angle is in an appropriate
+            range before the calibration or not. Default is True.
+        temperature_check (bool): Check the temperature of various components
+            are within operational limits before the calibration or not.
+            Default is True.
 
     """
     try:


### PR DESCRIPTION
Add the following arguments in `calibration()` in `wiregrid.py`:
* `elevation_check`
* `boresight_check`
* `temperature_check`

During the commissioning phase, we are planning to have regular wiregrid calibrations. Sometimes, we want to do the calibration in unusual conditions. So, I added the three arguments in the `calibration()` to allow us to remove the elevation angle, boresight angle, and temperature checks before the calibration.