### PR TITLE
Stop all SMuRF streams before waiting

### DIFF
--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -364,9 +364,12 @@ def stream(state, tag=None, subtype=None):
                 clients_to_remove.append(smurf)
 
     else:
+        print('Stopping SMuRF streams.')
         for smurf in run.CLIENTS['smurf']:
-            print(f'Turning off stream from {smurf.instance_id}.')
             smurf.stream.stop()
+
+        for smurf in run.CLIENTS['smurf']:
+            print(f'Waiting for stream from {smurf.instance_id} to stop.')
             resp = smurf.stream.wait()
             try:
                 check_response(smurf, resp)


### PR DESCRIPTION
This will help with potential keyboard interrupts due to impatient users, and will mitigate the problem with lack of error handling a bit, since this will call `.stop()` on all clients before an error can crop up. (Though adding error handling is next on the todo list.)

Resolves #168.