### PR TITLE
Handle missing 'op_name' key in response

### DIFF
--- a/src/sorunlib/_internal.py
+++ b/src/sorunlib/_internal.py
@@ -42,7 +42,11 @@ def check_response(client, response):
             initial request or after completion) or the response has timed out.
 
     """
-    op = response.session['op_name']
+    try:
+        op = response.session['op_name']
+    except KeyError:
+        error = f"Unable to parse response from {client}:\n{str(response)}"
+        raise RuntimeError(error)
     instance = client.instance_id
 
     _check_error(client, response)

--- a/tests/test__internal.py
+++ b/tests/test__internal.py
@@ -25,12 +25,19 @@ class MockClient:
         self.test_op = MagicMock()
 
 
+# Attempt to recreate https://github.com/simonsobs/sorunlib/issues/174
+malformed_session = create_session('test', success=False)
+malformed_session.pop('op_name')
+
 invalid_responses = [(MockClient(), OCSReply(ocs.TIMEOUT,
                                              'msg',
                                              create_session('test', success=True))),
                      (MockClient(), OCSReply(ocs.ERROR,
                                              'msg',
-                                             create_session('test', success=False)))]
+                                             create_session('test', success=False))),
+                     (MockClient(), OCSReply(ocs.ERROR,
+                                             'msg',
+                                             malformed_session))]
 
 valid_responses = [
     (MockClient(), OCSReply(ocs.OK, 'msg', create_session('test', success=True)))]


### PR DESCRIPTION
Fixes #174.

I'm still not sure what caused this or what the malformed response even looked like. But I created a test with a mostly valid response, just missing the `op_name` key, which will hit this `KeyError`.

We report the response and client it came from when raising a `RuntimeError`, which in the case of this failed pysmurf-controller will catch it, log the error, and drop the client from further commanding.