### PR TITLE
add time_constant function

### DIFF
--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -3,12 +3,18 @@ from sorunlib._internal import check_response
 
 
 def _get_direction():
-    """Return the rotational direction ('cw' or 'ccw') of the HWP.
-    'ccw' means counter-clockwise rotation seen from the sky to window. (+Hz)
-    'cw' means clockwise rotation seen from the sky to window. (-Hz)
+    """Get the rotational direction ('cw' or 'ccw') of the HWP. The direction
+    is determined in part by the configuration of the HWP supervisor agent. For
+    details see the `HWP Supervisor agent docs <docs_>`_.
+
+    * 'cw' is clockwise as seen from the sky to window.
+    * 'ccw' is counter-clockwise as seen from the sky to window.
 
     Returns:
-        str: The direction of the hwp, either 'ccw' or 'cw'
+        str: The direction of the HWP, either 'cw' or 'ccw'.
+
+    Raises:
+        RuntimeError: If the direction is not either 'cw' or 'ccw'.
 
     .. _docs: https://socs.readthedocs.io/en/main/agents/hwp_supervisor_agent.html
 
@@ -17,7 +23,7 @@ def _get_direction():
     resp = hwp.monitor.status()
     direction = resp.session['data']['hwp_state']['direction']
 
-    if direction not in ['ccw', 'cw']:
+    if direction not in ['cw', 'ccw']:
         raise RuntimeError("The HWP direction is unknown. Aborting...")
 
     return direction

--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -46,9 +46,9 @@ def stop(active=True, brake_voltage=None):
 
 
 def get_direction():
-    """Return the rotational direction ('ccw' or 'cw') of the HWP.
-    'ccw' means counter-clockwise rotation seen from the sky to window.
+    """Return the rotational direction ('cw' or 'ccw') of the HWP.
     'cw' means clockwise rotation seen from the sky to window.
+    'ccw' means counter-clockwise rotation seen from the sky to window.
 
     Args:
         None
@@ -60,7 +60,7 @@ def get_direction():
     resp = hwp.monitor.status()
     direction = resp.session['data']['hwp_state']['direction']
 
-    if direction not in ['ccw', 'cw']:
+    if direction not in ['cw', 'ccw']:
         raise RuntimeError("The HWP direction is unknown. Aborting...")
 
     return direction

--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -43,3 +43,33 @@ def stop(active=True, brake_voltage=None):
     else:
         resp = hwp.pmx_off(wait_stop=True)
         check_response(hwp, resp)
+
+
+def get_direction():
+    """Return the rotational direction of the HWP.
+    If True, it is counter-clockwise (CCW) seen from the sky to window.
+    If False, it is clockwise (CW).
+
+    Args:
+        None
+
+    .. _docs: https://socs.readthedocs.io/en/main/agents/hwp_supervisor_agent.html
+
+    """
+    hwp = run.CLIENTS['hwp']
+
+    resp = hwp.monitor.status()
+    pid_direction = resp.session['data']['hwp_state']['pid_direction']
+    if pid_direction == 0:
+        is_forward = True
+    elif pid_direction == 1:
+        is_forward = False
+    else:
+        raise RuntimeError("the hwp direction is unknown. aborting...")
+
+    forward_is_cw = hwp.forward_is_cw  # TODO: Need to check if this is possible
+
+    if is_forward ^ forward_is_cw:
+        return True
+    else:
+        return False

--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -46,9 +46,9 @@ def stop(active=True, brake_voltage=None):
 
 
 def get_direction():
-    """Return the rotational direction of the HWP.
-    If True, it is counter-clockwise (CCW) seen from the sky to window.
-    If False, it is clockwise (CW).
+    """Return the rotational direction ('cw' or 'ccw') of the HWP.
+    'cw' means clockwise rotation seen from the sky to window.
+    'ccw' means counter-clockwise rotation seen from the sky to window.
 
     Args:
         None
@@ -57,19 +57,10 @@ def get_direction():
 
     """
     hwp = run.CLIENTS['hwp']
-
     resp = hwp.monitor.status()
-    pid_direction = resp.session['data']['hwp_state']['pid_direction']
-    if pid_direction == 0:
-        is_forward = True
-    elif pid_direction == 1:
-        is_forward = False
-    else:
+    direction = resp.session['data']['hwp_state']['direction']
+
+    if direction not in ['cw', 'ccw']:
         raise RuntimeError("The HWP direction is unknown. Aborting...")
 
-    forward_is_cw = hwp.forward_is_cw  # TODO: Need to check if this is possible
-
-    if is_forward ^ forward_is_cw:
-        return True
-    else:
-        return False
+    return direction

--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -2,6 +2,27 @@ import sorunlib as run
 from sorunlib._internal import check_response
 
 
+def _get_direction():
+    """Return the rotational direction ('cw' or 'ccw') of the HWP.
+    'cw' means clockwise rotation seen from the sky to window. (+Hz)
+    'ccw' means counter-clockwise rotation seen from the sky to window. (-Hz)
+
+    Args:
+        None
+
+    .. _docs: https://socs.readthedocs.io/en/main/agents/hwp_supervisor_agent.html
+
+    """
+    hwp = run.CLIENTS['hwp']
+    resp = hwp.monitor.status()
+    direction = resp.session['data']['hwp_state']['direction']
+
+    if direction not in ['cw', 'ccw']:
+        raise RuntimeError("The HWP direction is unknown. Aborting...")
+
+    return direction
+
+
 # Public API
 def set_freq(freq):
     """Set the rotational frequency of the HWP.
@@ -43,24 +64,3 @@ def stop(active=True, brake_voltage=None):
     else:
         resp = hwp.pmx_off(wait_stop=True)
         check_response(hwp, resp)
-
-
-def get_direction():
-    """Return the rotational direction ('cw' or 'ccw') of the HWP.
-    'cw' means clockwise rotation seen from the sky to window. (+Hz)
-    'ccw' means counter-clockwise rotation seen from the sky to window. (-Hz)
-
-    Args:
-        None
-
-    .. _docs: https://socs.readthedocs.io/en/main/agents/hwp_supervisor_agent.html
-
-    """
-    hwp = run.CLIENTS['hwp']
-    resp = hwp.monitor.status()
-    direction = resp.session['data']['hwp_state']['direction']
-
-    if direction not in ['cw', 'ccw']:
-        raise RuntimeError("The HWP direction is unknown. Aborting...")
-
-    return direction

--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -65,7 +65,7 @@ def get_direction():
     elif pid_direction == 1:
         is_forward = False
     else:
-        raise RuntimeError("the hwp direction is unknown. aborting...")
+        raise RuntimeError("The HWP direction is unknown. Aborting...")
 
     forward_is_cw = hwp.forward_is_cw  # TODO: Need to check if this is possible
 

--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -46,9 +46,9 @@ def stop(active=True, brake_voltage=None):
 
 
 def get_direction():
-    """Return the rotational direction ('cw' or 'ccw') of the HWP.
-    'cw' means clockwise rotation seen from the sky to window.
+    """Return the rotational direction ('ccw' or 'cw') of the HWP.
     'ccw' means counter-clockwise rotation seen from the sky to window.
+    'cw' means clockwise rotation seen from the sky to window.
 
     Args:
         None
@@ -60,7 +60,7 @@ def get_direction():
     resp = hwp.monitor.status()
     direction = resp.session['data']['hwp_state']['direction']
 
-    if direction not in ['cw', 'ccw']:
+    if direction not in ['ccw', 'cw']:
         raise RuntimeError("The HWP direction is unknown. Aborting...")
 
     return direction

--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -47,8 +47,8 @@ def stop(active=True, brake_voltage=None):
 
 def get_direction():
     """Return the rotational direction ('cw' or 'ccw') of the HWP.
-    'cw' means clockwise rotation seen from the sky to window.
-    'ccw' means counter-clockwise rotation seen from the sky to window.
+    'cw' means clockwise rotation seen from the sky to window. (+Hz)
+    'ccw' means counter-clockwise rotation seen from the sky to window. (-Hz)
 
     Args:
         None

--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -4,11 +4,11 @@ from sorunlib._internal import check_response
 
 def _get_direction():
     """Return the rotational direction ('cw' or 'ccw') of the HWP.
-    'cw' means clockwise rotation seen from the sky to window. (+Hz)
-    'ccw' means counter-clockwise rotation seen from the sky to window. (-Hz)
+    'ccw' means counter-clockwise rotation seen from the sky to window. (+Hz)
+    'cw' means clockwise rotation seen from the sky to window. (-Hz)
 
-    Args:
-        None
+    Returns:
+        str: The direction of the hwp, either 'ccw' or 'cw'
 
     .. _docs: https://socs.readthedocs.io/en/main/agents/hwp_supervisor_agent.html
 
@@ -17,7 +17,7 @@ def _get_direction():
     resp = hwp.monitor.status()
     direction = resp.session['data']['hwp_state']['direction']
 
-    if direction not in ['cw', 'ccw']:
+    if direction not in ['ccw', 'cw']:
         raise RuntimeError("The HWP direction is unknown. Aborting...")
 
     return direction

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -227,7 +227,7 @@ def _check_hwp_direction():
     """
     hwp = run.CLIENTS['hwp']
     resp = hwp.monitor.status()
-    pid_direction = resp.session['data']['hwp_status']['pid_direction']
+    pid_direction = resp.session['data']['hwp_state']['pid_direction']
     if pid_direction == 0:
         direction = 'forward'
     elif pid_direction == 1:

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -217,6 +217,7 @@ def _check_wiregrid_position():
     return position
 
 
+# TODO: Should be changed to check CCW or CW
 def _check_hwp_direction():
     """Check the HWP direction by referring to the 'direction' in session.data
        of the HWP PID Agent via the HWP Supervisor Agent.
@@ -233,7 +234,7 @@ def _check_hwp_direction():
     elif pid_direction == 1:
         direction = 'backward'
     else:
-        raise RuntimeError("The HWP direction is unknown. Aborting...")
+        raise RuntimeError("the hwp direction is unknown. aborting...")
     return direction
 
 

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -360,7 +360,7 @@ def time_constant(num_repeats=1):
     # Check the current HWP direction
     try:
         # return 'cw' or 'ccw'
-        current_hwp_direction = run.hwp.get_direction()
+        current_hwp_direction = run.hwp._get_direction()
     except RuntimeError as e:
         error = "Wiregrid time constant measurment was failed " + \
                 "due to the failure in getting hwp direction. " + str(e)

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -359,7 +359,7 @@ def time_constant(num_repeats=1):
 
     # Check the current HWP direction
     try:
-        # return 'cw' or 'ccw'
+        # return 'ccw' or 'cw'
         current_hwp_direction = run.hwp._get_direction()
     except RuntimeError as e:
         error = "Wiregrid time constant measurment was failed " + \
@@ -389,10 +389,10 @@ def time_constant(num_repeats=1):
         run.smurf.stream('off')
 
     for i in range(num_repeats):
-        if current_hwp_direction == 'cw':
-            target_hwp_direction = 'ccw'
-        elif current_hwp_direction == 'ccw':
+        if current_hwp_direction == 'ccw':
             target_hwp_direction = 'cw'
+        elif current_hwp_direction == 'cw':
+            target_hwp_direction = 'ccw'
 
         # Bias step (the wire grid is on the window)
         # before stopping the HWP
@@ -432,10 +432,10 @@ def time_constant(num_repeats=1):
                          f'hwp_change_stop_to_{target_hwp_direction}' + el_tag
             run.smurf.stream('on', tag=stream_tag, subtype='cal')
             # Spin up the HWP reversely
-            if target_hwp_direction == 'cw':
-                run.hwp.set_freq(freq=-2.0)
-            elif target_hwp_direction == 'ccw':
+            if target_hwp_direction == 'ccw':
                 run.hwp.set_freq(freq=2.0)
+            elif target_hwp_direction == 'cw':
+                run.hwp.set_freq(freq=-2.0)
             current_hwp_direction = target_hwp_direction
         finally:
             # Stop SMuRF streams

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -209,11 +209,11 @@ def _check_wiregrid_position():
         position = 'inside'
     else:
         raise RuntimeError("The wiregrid position is unknown. The limitswitch response is like this:\n" +
-                           "LSR1: {}\n".format('ON' if ls_status['LSR1'] == 1 else 'OFF') +
-                           "LSL1: {}\n".format('ON' if ls_status['LSL1'] == 1 else 'OFF') +
-                           "LSR2: {}\n".format('ON' if ls_status['LSR2'] == 1 else 'OFF') +
-                           "LSL2: {}\n".format('ON' if ls_status['LSL2'] == 1 else 'OFF') +
-                           "Aborting...")
+                           "LSR1: {}\n".format('ON' if ls_status['LSR1'] == 1 else 'OFF')
+                           + "LSL1: {}\n".format('ON' if ls_status['LSL1'] == 1 else 'OFF')
+                           + "LSR2: {}\n".format('ON' if ls_status['LSR2'] == 1 else 'OFF')
+                           + "LSL2: {}\n".format('ON' if ls_status['LSL2'] == 1 else 'OFF')
+                           + "Aborting...")
     return position
 
 
@@ -234,7 +234,7 @@ def _stop_hwp_with_wiregrid():
 
 def _spin_hwp_with_wiregrid(target_hwp_direction):
     """Spin the HWP to the target direction at 2Hz after comfirming the wiregrid is inserted.
-    
+
     Args:
         target_hwp_direction (str): Target HWP direction, 'forward' or 'backward'.
     """
@@ -259,14 +259,14 @@ def _spin_hwp_with_wiregrid(target_hwp_direction):
 
 def _reverse_hwp_with_wiregrid(initial_hwp_direction, streaming=False, stepwise_before=False, stepwise_after=False):
     """Change the HWP direction after comfirming the wiregrid is inserted.
-    
+
     Args:
         initial_hwp_direction (str): Initial HWP direction, 'forward' or 'backward'.
         streaming (bool): Do SMuRF streaming during the HWP direction chaging or not . Default is False.
         stepwise_before (bool): Do stepwise rotation before changing HWP direction or not. Default is False.
         stepwise_after (bool): Do stepwise rotation after changing HWP direction or not. Default is False.
     """
-    if initial_hwp_direction not in ['forward', 'backward']: 
+    if initial_hwp_direction not in ['forward', 'backward']:
         raise RuntimeError("Initial HWP direction should be either 'forward' or 'backward'. Aborting...")
 
     current_hwp_direction = initial_hwp_direction
@@ -293,7 +293,7 @@ def _reverse_hwp_with_wiregrid(initial_hwp_direction, streaming=False, stepwise_
         # Spin up the HWP in the opposite direction
         _spin_hwp_with_wiregrid(target_hwp_direction)
         current_hwp_direction = target_hwp_direction
-        # Stepwise rotation after spinning up the HWP 
+        # Stepwise rotation after spinning up the HWP
         if stepwise_after:
             rotate(False)
     finally:
@@ -416,7 +416,7 @@ def calibrate(continuous=False, elevation_check=True, boresight_check=True,
 def time_constant(initial_hwp_direction, stepwise_first=True, stepwise_last=True, stepwise_mid=False, repeat=1):
     """
     Run a wiregrid time constant measurement.
-    
+
     Args:
         initial_hwp_direction (str): Initial HWP direction, 'forward' or 'backward'.
         stepwise_first (bool): Do stepwise rotation or not before the first HWP speed change. Default is True.
@@ -426,7 +426,7 @@ def time_constant(initial_hwp_direction, stepwise_first=True, stepwise_last=True
             If this is odd, the HWP direction will be changed to the opposite of the initial direction.
             If this is even, the HWP direction will be the same as the initial direction.
     """
-    
+
     # Check the initial HWP direction
     if initial_hwp_direction not in ['forward', 'backward']:
         raise RuntimeError("Initial HWP direction should be either 'forward' or 'backward'. Aborting...")
@@ -439,7 +439,7 @@ def time_constant(initial_hwp_direction, stepwise_first=True, stepwise_last=True
     _check_agents_online()
     _check_motor_on()
     _check_telescope_position(elevation_check=True, boresight_check=False)
-    
+
     if _check_zenith:
         el_tag = ', wg_el90'
     else:
@@ -478,7 +478,7 @@ def time_constant(initial_hwp_direction, stepwise_first=True, stepwise_last=True
         if stepwise_mid and i != 0:
             # Stepwise rotation between changing HWP speed
             stepwise_before = True
-        if stepwise_last and i == repeat-1:
+        if stepwise_last and i == repeat - 1:
             # Stepwise rotation after the last HWP speed change
             stepwise_after = True
 

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -406,7 +406,6 @@ def time_constant(num_repeats=1):
     _check_motor_on()
     _check_telescope_position(elevation_check=True, boresight_check=False)
     position = _check_wiregrid_position()
-    print(position)
     if _check_wiregrid_position() == 'inside':
         error = "The wiregrid is already inserted before the wiregrid time " + \
                 "constant measurement. Please inspect wiregrid and HWP " + \

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -425,7 +425,7 @@ def time_constant(num_repeats=1):
 
     # Bias step (the wire grid is off the window)
     bs_tag = 'wiregrid, wg_time_constant, wg_ejected, ' + \
-             f'hwp_2hz_{current_hwp_direction}' + el_tag
+             f'hwp_{current_hwp_direction}' + el_tag
     run.smurf.bias_step(tag=bs_tag, concurrent=True)
 
     # Insert the wiregrid with streaming
@@ -433,7 +433,7 @@ def time_constant(num_repeats=1):
     try:
         # Enable SMuRF streams
         stream_tag = 'wiregrid, wg_time_constant, wg_inserting, ' + \
-                     f'hwp_2hz_{current_hwp_direction}' + el_tag
+                     f'hwp_{current_hwp_direction}' + el_tag
         run.smurf.stream('on', tag=stream_tag, subtype='cal')
         # Insert the wiregrid
         insert()
@@ -445,7 +445,7 @@ def time_constant(num_repeats=1):
     for i in range(num_repeats):
         # Bias step (the wire grid is on the window)
         bs_tag = 'wiregrid, wg_time_constant, wg_inserted, ' + \
-            f'hwp_2hz_{current_hwp_direction}' + el_tag
+            f'hwp_{current_hwp_direction}' + el_tag
         run.smurf.bias_step(tag=bs_tag, concurrent=True)
 
         stepwise_before = True if i == 0 else False
@@ -475,7 +475,7 @@ def time_constant(num_repeats=1):
 
     # Bias step (the wire grid is on the window)
     bs_tag = 'wiregrid, wg_time_constant, wg_inserted, ' + \
-             f'hwp_2hz_{current_hwp_direction}' + el_tag
+             f'hwp_{current_hwp_direction}' + el_tag
     run.smurf.bias_step(tag=bs_tag, concurrent=True)
 
     # Eject the wiregrid with streaming
@@ -483,7 +483,7 @@ def time_constant(num_repeats=1):
     try:
         # Enable SMuRF streams
         stream_tag = 'wiregrid, wg_time_constant, wg_ejecting, ' + \
-                     f'hwp_2hz_{current_hwp_direction}' + el_tag
+                     f'hwp_{current_hwp_direction}' + el_tag
         run.smurf.stream('on', tag=stream_tag, subtype='cal')
         # Eject the wiregrid
         eject()
@@ -494,5 +494,5 @@ def time_constant(num_repeats=1):
 
     # Bias step (the wire grid is off the window)
     bs_tag = 'wiregrid, wg_time_constant, wg_ejected, ' + \
-             f'hwp_2hz_{current_hwp_direction}' + el_tag
+             f'hwp_{current_hwp_direction}' + el_tag
     run.smurf.bias_step(tag=bs_tag, concurrent=True)

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -238,46 +238,6 @@ def _check_hwp_direction():
     return direction
 
 
-def _reverse_hwp_direction(initial_hwp_direction, stepwise_before=False,
-                           stepwise_after=False):
-    """Reverse the HWP rotation direction from ``initial_hwp_direction``.
-
-    Args:
-        initial_hwp_direction (str): The initial HWP direction, either 'forward'
-            or 'backward'.
-        stepwise_before (bool): Do stepwise rotation before changing HWP direction
-            or not. Default is False.
-        stepwise_after (bool): Do stepwise rotation after changing HWP direction
-            or not. Default is False.
-
-    Returns:
-        str: The current HWP direction after reversing.
-    """
-    # Set the target HWP direction
-    current_hwp_direction = initial_hwp_direction
-    if current_hwp_direction == 'forward':
-        target_hwp_direction = 'backward'
-    elif current_hwp_direction == 'backward':
-        target_hwp_direction = 'forward'
-    else:
-        raise RuntimeError("Invalid initial hwp rotation direction. Aborting...")
-    # Run stepwise rotation before stopping the HWP
-    if stepwise_before:
-        rotate(False)
-    # Stop the HWP
-    run.hwp.stop(active=True)
-    # Spin up the HWP reversely
-    if target_hwp_direction == 'forward':
-        run.hwp.set_freq(freq=2.0)
-    elif target_hwp_direction == 'backward':
-        run.hwp.set_freq(freq=-2.0)
-    current_hwp_direction = target_hwp_direction
-    # Run stepwise rotation after spinning up the HWP
-    if stepwise_after:
-        rotate(False)
-    return current_hwp_direction
-
-
 # Public API
 def insert():
     """Insert the wiregrid."""

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -234,7 +234,7 @@ def _check_hwp_direction():
     elif pid_direction == 1:
         direction = 'backward'
     else:
-        raise RuntimeError("the hwp direction is unknown. aborting...")
+        raise RuntimeError("The HWP direction is unknown. Aborting...")
     return direction
 
 

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -459,7 +459,7 @@ def time_constant(num_repeats=1):
             if stepwise_before:
                 # Enable SMuRF streams
                 stream_tag = 'wiregrid, wg_time_constant, ' + \
-                         f'wg_stepwise_before' + el_tag
+                    f'wg_stepwise_before' + el_tag
                 run.smurf.stream('on', tag=stream_tag, subtype='cal')
                 rotate(False)
                 # Stop SMuRF streams
@@ -492,13 +492,13 @@ def time_constant(num_repeats=1):
             if stepwise_after:
                 # Enable SMuRF streams
                 stream_tag = 'wiregrid, wg_time_constant, ' + \
-                         f'wg_stepwise_after' + el_tag
+                    f'wg_stepwise_after' + el_tag
                 run.smurf.stream('on', tag=stream_tag, subtype='cal')
                 rotate(False)
                 # Stop SMuRF streams
                 run.smurf.stream('off')
 
-            #current_hwp_direction = \
+            # current_hwp_direction = \
             #    _reverse_hwp_direction(current_hwp_direction,
             #                           stepwise_before=stepwise_before,
             #                           stepwise_after=stepwise_after)

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -452,8 +452,18 @@ def time_constant(initial_hwp_direction, stepwise_first=True, stepwise_last=True
     bs_tag = f'biasstep, wg_time_constant, wg_ejected, hwp_2hz_{current_hwp_direction}' + el_tag
     run.smurf.bias_step(tag=bs_tag, concurrent=True)
 
-    # Insert the wiregrid
-    insert()
+    # Insert the wiregrid with streaming
+    time.sleep(5)
+    try:
+        # Enable SMuRF streams
+        stream_tag = f'wg_time_constant, wg_inserting, hwp_2hz_{current_hwp_direction}' + el_tag
+        run.smurf.stream('on', tag=stream_tag, subtype='cal')
+        # Insert the wiregrid
+        insert()
+    finally:
+        # Stop SMuRF streams
+        run.smurf.stream('off')
+    time.sleep(5)
 
     for i in range(repeat):
         # Bias step (the wire grid is on the window)
@@ -482,8 +492,18 @@ def time_constant(initial_hwp_direction, stepwise_first=True, stepwise_last=True
     bs_tag = f'biasstep, wg_time_constant, wg_inserted, hwp_2hz_{current_hwp_direction}' + el_tag
     run.smurf.bias_step(tag=bs_tag, concurrent=True)
 
-    # Eject the wiregrid
-    eject()
+    # Eject the wiregrid with streaming
+    time.sleep(5)
+    try:
+        # Enable SMuRF streams
+        stream_tag = f'wg_time_constant, wg_ejecting, hwp_2hz_{current_hwp_direction}' + el_tag
+        run.smurf.stream('on', tag=stream_tag, subtype='cal')
+        # Eject the wiregrid
+        eject()
+    finally:
+        # Stop SMuRF streams
+        run.smurf.stream('off')
+    time.sleep(5)
 
     # Bias step (the wire grid is off the window)
     bs_tag = f'biasstep, wg_time_constant, wg_ejected, hwp_2hz_{current_hwp_direction}' + el_tag

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -221,7 +221,7 @@ def _check_hwp_direction():
     """Check the HWP direction.
 
     Returns:
-        str: The HWP direction, either 'ccw' or 'cw'.
+        str: The HWP direction, either 'cw' or 'ccw'.
 
     """
     try:
@@ -421,7 +421,8 @@ def time_constant(num_repeats=1):
             try:
                 # Enable SMuRF streams
                 stream_tag = 'wiregrid, wg_time_constant, ' + \
-                             'wg_stepwise_before' + el_tag
+                             'wg_stepwise, hwp_{current_hwp_directoin}' + \
+                             el_tag
                 run.smurf.stream('on', tag=stream_tag, subtype='cal')
                 # Run stepwise rotation
                 rotate(False)
@@ -433,7 +434,7 @@ def time_constant(num_repeats=1):
         try:
             # Enable SMuRF streams
             stream_tag = 'wiregrid, wg_time_constant, ' + \
-                         f'hwp_{current_hwp_direction}_to_0' + el_tag
+                         f'hwp_change_{current_hwp_direction}_to_0' + el_tag
             run.smurf.stream('on', tag=stream_tag, subtype='cal')
             # Stop the HWP
             run.hwp.stop(active=True)
@@ -445,12 +446,12 @@ def time_constant(num_repeats=1):
         try:
             # Enable SMuRF streams
             stream_tag = 'wiregrid, wg_time_constant, ' + \
-                         f'hwp_0_to_{target_hwp_direction}' + el_tag
+                         f'hwp_change_0_to_{target_hwp_direction}' + el_tag
             run.smurf.stream('on', tag=stream_tag, subtype='cal')
             # Spin up the HWP reversely
-            if target_hwp_direction == 'ccw':
+            if target_hwp_direction == 'cw':
                 run.hwp.set_freq(freq=2.0)
-            elif target_hwp_direction == 'cw':
+            elif target_hwp_direction == 'ccw':
                 run.hwp.set_freq(freq=-2.0)
             current_hwp_direction = target_hwp_direction
         finally:
@@ -462,7 +463,8 @@ def time_constant(num_repeats=1):
             try:
                 # Enable SMuRF streams
                 stream_tag = 'wiregrid, wg_time_constant, ' + \
-                             'wg_stepwise_after' + el_tag
+                             'wg_stepwise, hwp_{current_hwp_directoin}' + \
+                             el_tag
                 run.smurf.stream('on', tag=stream_tag, subtype='cal')
                 # Run stepwise rotation
                 rotate(False)

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -427,9 +427,9 @@ def time_constant(num_repeats=1):
     bs_tag = 'wiregrid, wg_time_constant, wg_ejected, ' + \
              f'hwp_{current_hwp_direction}' + el_tag
     run.smurf.bias_step(tag=bs_tag, concurrent=True)
+    time.sleep(5)
 
     # Insert the wiregrid with streaming
-    time.sleep(5)
     try:
         # Enable SMuRF streams
         stream_tag = 'wiregrid, wg_time_constant, wg_inserting, ' + \
@@ -437,87 +437,85 @@ def time_constant(num_repeats=1):
         run.smurf.stream('on', tag=stream_tag, subtype='cal')
         # Insert the wiregrid
         insert()
+        time.sleep(5)
     finally:
         # Stop SMuRF streams
         run.smurf.stream('off')
-    time.sleep(5)
 
     for i in range(num_repeats):
         # Bias step (the wire grid is on the window)
         bs_tag = 'wiregrid, wg_time_constant, wg_inserted, ' + \
-            f'hwp_{current_hwp_direction}' + el_tag
+                 f'hwp_{current_hwp_direction}' + el_tag
         run.smurf.bias_step(tag=bs_tag, concurrent=True)
 
         stepwise_before = True if i == 0 else False
         stepwise_after = True
-        try:
-            if current_hwp_direction == 'forward':
-                target_hwp_direction = 'backward'
-            elif current_hwp_direction == 'backward':
-                target_hwp_direction = 'forward'
-            # Run stepwise rotation before stopping the HWP
-            if stepwise_before:
+        if current_hwp_direction == 'forward':
+            target_hwp_direction = 'backward'
+        elif current_hwp_direction == 'backward':
+            target_hwp_direction = 'forward'
+
+        # Run stepwise rotation before stopping the HWP
+        if stepwise_before:
+            try:
                 # Enable SMuRF streams
                 stream_tag = 'wiregrid, wg_time_constant, ' + \
-                    f'wg_stepwise_before' + el_tag
+                             'wg_stepwise_before' + el_tag
                 run.smurf.stream('on', tag=stream_tag, subtype='cal')
+                # Run stepwise rotation
                 rotate(False)
+            finally:
                 # Stop SMuRF streams
                 run.smurf.stream('off')
 
+        # Stop the HWP with streaming
+        try:
             # Enable SMuRF streams
             stream_tag = 'wiregrid, wg_time_constant, ' + \
                          f'hwp_{current_hwp_direction}_to_0' + el_tag
             run.smurf.stream('on', tag=stream_tag, subtype='cal')
             # Stop the HWP
             run.hwp.stop(active=True)
+        finally:
             # Stop SMuRF streams
             run.smurf.stream('off')
 
+        # Spin up the HWP reversely with streaming
+        try:
             # Enable SMuRF streams
             stream_tag = 'wiregrid, wg_time_constant, ' + \
                          f'hwp_0_to_{target_hwp_direction}' + el_tag
             run.smurf.stream('on', tag=stream_tag, subtype='cal')
-            # Reverse the HWP with streaming and a stepwise rotation
             # Spin up the HWP reversely
             if target_hwp_direction == 'forward':
                 run.hwp.set_freq(freq=2.0)
             elif target_hwp_direction == 'backward':
                 run.hwp.set_freq(freq=-2.0)
             current_hwp_direction = target_hwp_direction
-            # Stop SMuRF streams
-            run.smurf.stream('off')
-
-            # Run stepwise rotation after spinning up the HWP
-            if stepwise_after:
-                # Enable SMuRF streams
-                stream_tag = 'wiregrid, wg_time_constant, ' + \
-                    f'wg_stepwise_after' + el_tag
-                run.smurf.stream('on', tag=stream_tag, subtype='cal')
-                rotate(False)
-                # Stop SMuRF streams
-                run.smurf.stream('off')
-
-            # current_hwp_direction = \
-            #    _reverse_hwp_direction(current_hwp_direction,
-            #                           stepwise_before=stepwise_before,
-            #                           stepwise_after=stepwise_after)
-        except RuntimeError as e:
-            error = "The wiregrid time constant measurement failed. " + \
-                    "Please inspect wiregrid and HWP before continuing " + \
-                    "observations.\n" + str(e)
-            raise RuntimeError(error)
         finally:
             # Stop SMuRF streams
             run.smurf.stream('off')
+
+        # Run stepwise rotation after spinning up the HWP
+        if stepwise_after:
+            try:
+                # Enable SMuRF streams
+                stream_tag = 'wiregrid, wg_time_constant, ' + \
+                             'wg_stepwise_after' + el_tag
+                run.smurf.stream('on', tag=stream_tag, subtype='cal')
+                # Run stepwise rotation
+                rotate(False)
+            finally:
+                # Stop SMuRF streams
+                run.smurf.stream('off')
 
     # Bias step (the wire grid is on the window)
     bs_tag = 'wiregrid, wg_time_constant, wg_inserted, ' + \
              f'hwp_{current_hwp_direction}' + el_tag
     run.smurf.bias_step(tag=bs_tag, concurrent=True)
+    time.sleep(5)
 
     # Eject the wiregrid with streaming
-    time.sleep(5)
     try:
         # Enable SMuRF streams
         stream_tag = 'wiregrid, wg_time_constant, wg_ejecting, ' + \
@@ -525,10 +523,10 @@ def time_constant(num_repeats=1):
         run.smurf.stream('on', tag=stream_tag, subtype='cal')
         # Eject the wiregrid
         eject()
+        time.sleep(5)
     finally:
         # Stop SMuRF streams
         run.smurf.stream('off')
-    time.sleep(5)
 
     # Bias step (the wire grid is off the window)
     bs_tag = 'wiregrid, wg_time_constant, wg_ejected, ' + \

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -404,7 +404,7 @@ def time_constant(num_repeats=1):
         try:
             # Enable SMuRF streams
             stream_tag = 'wiregrid, wg_time_constant, ' + \
-                         'wg_stepwise, hwp_{current_hwp_directoin}' + \
+                         'wg_stepwise, hwp_{current_hwp_direction}' + \
                          el_tag
             run.smurf.stream('on', tag=stream_tag, subtype='cal')
             # Run stepwise rotation
@@ -445,7 +445,7 @@ def time_constant(num_repeats=1):
     try:
         # Enable SMuRF streams
         stream_tag = 'wiregrid, wg_time_constant, ' + \
-                     'wg_stepwise, hwp_{current_hwp_directoin}' + \
+                     'wg_stepwise, hwp_{current_hwp_direction}' + \
                      el_tag
         run.smurf.stream('on', tag=stream_tag, subtype='cal')
         # Run stepwise rotation

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -405,7 +405,7 @@ def time_constant(num_repeats=1):
     _check_agents_online()
     _check_motor_on()
     _check_telescope_position(elevation_check=True, boresight_check=False)
-    position = _check_wiregrid_position()
+    _check_wiregrid_position()
     if _check_wiregrid_position() == 'inside':
         error = "The wiregrid is already inserted before the wiregrid time " + \
                 "constant measurement. Please inspect wiregrid and HWP " + \

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -402,7 +402,7 @@ def time_constant(num_repeats=1):
                          el_tag
             run.smurf.stream('on', tag=stream_tag, subtype='cal')
             # Run stepwise rotation
-            rotate(False)
+            rotate(continuous=False)
         finally:
             run.smurf.stream('off')
 
@@ -439,7 +439,7 @@ def time_constant(num_repeats=1):
                      el_tag
         run.smurf.stream('on', tag=stream_tag, subtype='cal')
         # Run stepwise rotation
-        rotate(False)
+        rotate(continuous=False)
     finally:
         run.smurf.stream('off')
 

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -404,7 +404,7 @@ def time_constant(num_repeats=1):
         try:
             # Enable SMuRF streams
             stream_tag = 'wiregrid, wg_time_constant, ' + \
-                         'wg_stepwise, hwp_{current_hwp_direction}' + \
+                         f'wg_stepwise, hwp_{current_hwp_direction}' + \
                          el_tag
             run.smurf.stream('on', tag=stream_tag, subtype='cal')
             # Run stepwise rotation
@@ -445,7 +445,7 @@ def time_constant(num_repeats=1):
     try:
         # Enable SMuRF streams
         stream_tag = 'wiregrid, wg_time_constant, ' + \
-                     'wg_stepwise, hwp_{current_hwp_direction}' + \
+                     f'wg_stepwise, hwp_{current_hwp_direction}' + \
                      el_tag
         run.smurf.stream('on', tag=stream_tag, subtype='cal')
         # Run stepwise rotation

--- a/tests/test_hwp.py
+++ b/tests/test_hwp.py
@@ -33,7 +33,7 @@ def create_hwp_client(direction):
     client.monitor.status = MagicMock(return_value=reply)
 
     return client
-    
+
 
 @pytest.mark.parametrize('direction', ['cw', 'ccw'])
 def test_get_direction(patch_clients_satp, direction):

--- a/tests/test_hwp.py
+++ b/tests/test_hwp.py
@@ -36,7 +36,7 @@ def create_hwp_client(direction):
 
 
 @pytest.mark.parametrize('direction', ['cw', 'ccw'])
-def test_get_direction(patch_clients_satp, direction):
+def test__get_direction(patch_clients_satp, direction):
     hwp.run.CLIENTS['hwp'] = create_hwp_client(direction)
     ret = hwp._get_direction()
     if direction == 'cw':
@@ -47,7 +47,7 @@ def test_get_direction(patch_clients_satp, direction):
 
 
 @pytest.mark.parametrize('direction', [None, ''])
-def test_get_direction_invalid(patch_clients_satp, direction):
+def test__get_direction_invalid(patch_clients_satp, direction):
     hwp.run.CLIENTS['hwp'] = create_hwp_client(direction)
     with pytest.raises(RuntimeError) as e:
         hwp._get_direction()

--- a/tests/test_hwp.py
+++ b/tests/test_hwp.py
@@ -18,7 +18,7 @@ def create_hwp_client(direction):
     """Create a HWP client with mock acq Process session.data.
 
     Args:
-        direction (str): direction of the HWP. 'cw' (clockwise) or 'ccw' (counter-clockwise).
+        direction (str): direction of the HWP. 'ccw' (counter-clockwise) or 'cw' (clockwise).
 
     """
     client = MagicMock()
@@ -35,14 +35,14 @@ def create_hwp_client(direction):
     return client
 
 
-@pytest.mark.parametrize('direction', ['cw', 'ccw'])
+@pytest.mark.parametrize('direction', ['ccw', 'cw'])
 def test__get_direction(patch_clients_satp, direction):
     hwp.run.CLIENTS['hwp'] = create_hwp_client(direction)
     ret = hwp._get_direction()
-    if direction == 'cw':
-        assert ret == 'cw'
-    elif direction == 'ccw':
+    if direction == 'ccw':
         assert ret == 'ccw'
+    elif direction == 'cw':
+        assert ret == 'cw'
     hwp.run.CLIENTS['hwp'].monitor.status.assert_called_once()
 
 

--- a/tests/test_hwp.py
+++ b/tests/test_hwp.py
@@ -56,7 +56,7 @@ def test_set_freq(patch_clients_satp):
 
 
 @pytest.mark.parametrize('direction', ['cw', 'ccw'])
-def test_get_direction(direction):
+def test_get_direction(patch_clients_satp, direction):
     hwp.run.CLIENTS['hwp'] = create_hwp_client(direction)
     ret = hwp.get_direction()
     if direction == 'cw':
@@ -67,7 +67,7 @@ def test_get_direction(direction):
 
 
 @pytest.mark.parametrize('direction', [None, ''])
-def test_get_direction_invalid(direction):
+def test_get_direction_invalid(patch_clients_satp, direction):
     hwp.run.CLIENTS['hwp'] = create_hwp_client(direction)
     with pytest.raises(RuntimeError) as e:
         hwp.get_direction()

--- a/tests/test_hwp.py
+++ b/tests/test_hwp.py
@@ -33,6 +33,26 @@ def create_hwp_client(direction):
     client.monitor.status = MagicMock(return_value=reply)
 
     return client
+    
+
+@pytest.mark.parametrize('direction', ['cw', 'ccw'])
+def test_get_direction(patch_clients_satp, direction):
+    hwp.run.CLIENTS['hwp'] = create_hwp_client(direction)
+    ret = hwp._get_direction()
+    if direction == 'cw':
+        assert ret == 'cw'
+    elif direction == 'ccw':
+        assert ret == 'ccw'
+    hwp.run.CLIENTS['hwp'].monitor.status.assert_called_once()
+
+
+@pytest.mark.parametrize('direction', [None, ''])
+def test_get_direction_invalid(patch_clients_satp, direction):
+    hwp.run.CLIENTS['hwp'] = create_hwp_client(direction)
+    with pytest.raises(RuntimeError) as e:
+        hwp._get_direction()
+    assert str(e.value) == "The HWP direction is unknown. Aborting..."
+    hwp.run.CLIENTS['hwp'].monitor.status.assert_called_once()
 
 
 @pytest.mark.parametrize("active", [True, False])
@@ -53,23 +73,3 @@ def test_stop_brake_voltage(patch_clients_satp):
 def test_set_freq(patch_clients_satp):
     hwp.set_freq(freq=2.0)
     hwp.run.CLIENTS['hwp'].pid_to_freq.assert_called_with(target_freq=2.0)
-
-
-@pytest.mark.parametrize('direction', ['cw', 'ccw'])
-def test_get_direction(patch_clients_satp, direction):
-    hwp.run.CLIENTS['hwp'] = create_hwp_client(direction)
-    ret = hwp.get_direction()
-    if direction == 'cw':
-        assert ret == 'cw'
-    elif direction == 'ccw':
-        assert ret == 'ccw'
-    hwp.run.CLIENTS['hwp'].monitor.status.assert_called_once()
-
-
-@pytest.mark.parametrize('direction', [None, ''])
-def test_get_direction_invalid(patch_clients_satp, direction):
-    hwp.run.CLIENTS['hwp'] = create_hwp_client(direction)
-    with pytest.raises(RuntimeError) as e:
-        hwp.get_direction()
-    assert str(e.value) == "The HWP direction is unknown. Aborting..."
-    hwp.run.CLIENTS['hwp'].monitor.status.assert_called_once()

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch, call
 
 import ocs
 from ocs.ocs_client import OCSReply
-from sorunlib import wiregrid, hwp
+from sorunlib import wiregrid
 
 from util import create_session, create_patch_clients, mocked_clients
 
@@ -314,12 +314,11 @@ def test__check_wiregrid_position_invalid(position):
 
 
 @patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
-@patch('sorunlib.hwp.run.CLIENTS', mocked_clients())
 @patch('sorunlib.wiregrid.time.sleep', MagicMock())
 def test_time_constant_cw():
     # Setup all mock clients
     wiregrid.run.CLIENTS['acu'] = create_acu_client(180, 50, 0)
-    hwp.run.CLIENTS['hwp'] = create_hwp_client('cw')  # cw
+    wiregrid.run.hwp.get_direction = MagicMock(return_value='cw')  # cw
     wiregrid.run.CLIENTS['wiregrid']['actuator'] = \
         create_actuator_client(motor=1, position='outside')
     wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
@@ -367,7 +366,7 @@ def test_time_constant_cw():
 def test_time_constant_ccw_el90():
     # Setup all mock clients
     wiregrid.run.CLIENTS['acu'] = create_acu_client(180, 90, 0)
-    wiregrid.run.CLIENTS['hwp'] = create_hwp_client('ccw')  # ccw
+    wiregrid.run.hwp.get_direction = MagicMock(return_value='ccw')  # ccw
     wiregrid.run.CLIENTS['wiregrid']['actuator'] = \
         create_actuator_client(motor=1, position='outside')
     wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
@@ -416,7 +415,7 @@ def test_time_constant_ccw_el90():
 def test_time_constant_repeats():
     # Setup all mock clients
     wiregrid.run.CLIENTS['acu'] = create_acu_client(180, 50, 0)
-    wiregrid.run.CLIENTS['hwp'] = create_hwp_client('cw')
+    wiregrid.run.hwp.get_direction = MagicMock(return_value='cw')  # cw
     wiregrid.run.CLIENTS['wiregrid']['actuator'] = \
         create_actuator_client(motor=1, position='outside')
     wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -333,7 +333,7 @@ def test_time_constant_cw():
         call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_cw'),
         call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_cw'),
         call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_ccw'),
-        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_ccw'),
+        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_ccw')
     ]
 
     common_kwargs_of_streams = {
@@ -346,7 +346,7 @@ def test_time_constant_cw():
         'wiregrid, wg_time_constant, hwp_change_cw_to_stop',
         'wiregrid, wg_time_constant, hwp_change_stop_to_ccw',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_ccw',
-        'wiregrid, wg_time_constant, wg_ejecting, hwp_ccw',
+        'wiregrid, wg_time_constant, wg_ejecting, hwp_ccw'
     ]
     expected_calls_of_streams = [
         call(tag=stream_tag, subtype='cal', kwargs=common_kwargs_of_streams)
@@ -381,7 +381,7 @@ def test_time_constant_ccw_el90():
         call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_ccw, wg_el90'),
         call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_ccw, wg_el90'),
         call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_cw, wg_el90'),
-        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_cw, wg_el90'),
+        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_cw, wg_el90')
     ]
 
     common_kwargs_of_streams = {
@@ -394,7 +394,7 @@ def test_time_constant_ccw_el90():
         'wiregrid, wg_time_constant, hwp_change_ccw_to_stop, wg_el90',
         'wiregrid, wg_time_constant, hwp_change_stop_to_cw, wg_el90',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_cw, wg_el90',
-        'wiregrid, wg_time_constant, wg_ejecting, hwp_cw, wg_el90',
+        'wiregrid, wg_time_constant, wg_ejecting, hwp_cw, wg_el90'
     ]
     expected_calls_of_streams = [
         call(tag=stream_tag, subtype='cal', kwargs=common_kwargs_of_streams)
@@ -431,7 +431,7 @@ def test_time_constant_repeats():
         call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_cw'),
         call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_ccw'),
         call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_cw'),
-        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_cw'),
+        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_cw')
     ]
 
     common_kwargs_of_streams = {
@@ -447,7 +447,7 @@ def test_time_constant_repeats():
         'wiregrid, wg_time_constant, hwp_change_ccw_to_stop',
         'wiregrid, wg_time_constant, hwp_change_stop_to_cw',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_cw',
-        'wiregrid, wg_time_constant, wg_ejecting, hwp_cw',
+        'wiregrid, wg_time_constant, wg_ejecting, hwp_cw'
     ]
     expected_calls_of_streams = [
         call(tag=stream_tag, subtype='cal', kwargs=common_kwargs_of_streams)

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -344,11 +344,10 @@ def test__reverse_hwp_direction_initial_direction(initial_hwp_direction):
             mock_hwp_set_freq.assert_called_once_with(freq=2.0)
 
 
-@pytest.mark.parametrize('initial_hwp_direction', 'unknown')
 @patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
-def test__reverse_hwp_direction_initial_direction_failed(initial_hwp_direction):
+def test__reverse_hwp_direction_initial_direction_failed():
     with pytest.raises(RuntimeError):
-        wiregrid._reverse_hwp_direction(initial_hwp_direction, True, True)
+        wiregrid._reverse_hwp_direction('unknown', True, True)
 
 
 @pytest.mark.parametrize('stepwise_before, stepwise_after',

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -410,7 +410,6 @@ def test_time_constant_ccw_el90():
 
 
 @patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
-@patch('sorunlib.hwp.run.CLIENTS', mocked_clients())
 @patch('sorunlib.wiregrid.time.sleep', MagicMock())
 def test_time_constant_repeats():
     # Setup all mock clients

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -333,42 +333,6 @@ def test__check_hwp_direction_invalid():
     wiregrid.run.CLIENTS['hwp'].monitor.status.assert_called_once()
 
 
-@pytest.mark.parametrize('initial_hwp_direction', [('forward'), ('backward')])
-@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
-def test__reverse_hwp_direction_initial_direction(initial_hwp_direction):
-    with patch('sorunlib.wiregrid.run.hwp.set_freq') as mock_hwp_set_freq:
-        wiregrid._reverse_hwp_direction(initial_hwp_direction)
-        if initial_hwp_direction == 'forward':
-            mock_hwp_set_freq.assert_called_once_with(freq=-2.0)
-        elif initial_hwp_direction == 'backward':
-            mock_hwp_set_freq.assert_called_once_with(freq=2.0)
-
-
-@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
-def test__reverse_hwp_direction_initial_direction_failed():
-    with pytest.raises(RuntimeError):
-        wiregrid._reverse_hwp_direction('unknown', True, True)
-
-
-@pytest.mark.parametrize('stepwise_before, stepwise_after',
-                         [(True, True),
-                          (True, False),
-                          (False, True),
-                          (False, False)])
-@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
-def test__reverse_hwp_direction_stepwise(stepwise_before, stepwise_after):
-    with patch('sorunlib.wiregrid.rotate') as mock_rotate:
-        wiregrid._reverse_hwp_direction('forward',
-                                        stepwise_before=stepwise_before,
-                                        stepwise_after=stepwise_after)
-        if stepwise_before and stepwise_after:
-            assert mock_rotate.call_count == 2
-        elif not stepwise_before and not stepwise_after:
-            assert mock_rotate.call_count == 0
-        else:
-            assert mock_rotate.call_count == 1
-
-
 @patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
 @patch('sorunlib.wiregrid.time.sleep', MagicMock())
 def test_time_constant_forward():
@@ -520,21 +484,5 @@ def test_time_constant_wiregrid_position_failed():
     wiregrid.run.CLIENTS['wiregrid']['encoder'] = create_encoder_client()
     wiregrid.run.CLIENTS['wiregrid']['labjack'] = create_labjack_client()
 
-    with pytest.raises(RuntimeError):
-        wiregrid.time_constant(num_repeats=1)
-
-
-@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
-@patch('sorunlib.wiregrid.time.sleep', MagicMock())
-def test_time_constant_reverse_hwp_failed():
-    wiregrid.run.CLIENTS['acu'] = create_acu_client(180, 50, 0)
-    wiregrid.run.CLIENTS['hwp'] = create_hwp_client(0)
-    wiregrid.run.CLIENTS['wiregrid']['actuator'] = \
-        create_actuator_client(motor=1, position='outside')
-    wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
-    wiregrid.run.CLIENTS['wiregrid']['encoder'] = create_encoder_client()
-    wiregrid.run.CLIENTS['wiregrid']['labjack'] = create_labjack_client()
-
-    wiregrid.run.wiregrid._reverse_hwp_direction = MagicMock(side_effect=RuntimeError)
     with pytest.raises(RuntimeError):
         wiregrid.time_constant(num_repeats=1)

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -324,6 +324,7 @@ def test_time_constant_cw():
     wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
     wiregrid.run.CLIENTS['wiregrid']['encoder'] = create_encoder_client()
     wiregrid.run.CLIENTS['wiregrid']['labjack'] = create_labjack_client()
+    wiregrid.run.wiregrid.rotate = MagicMock()
 
     wiregrid.time_constant(num_repeats=1)
 
@@ -372,6 +373,7 @@ def test_time_constant_ccw_el90():
     wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
     wiregrid.run.CLIENTS['wiregrid']['encoder'] = create_encoder_client()
     wiregrid.run.CLIENTS['wiregrid']['labjack'] = create_labjack_client()
+    wiregrid.run.wiregrid.rotate = MagicMock()
 
     wiregrid.time_constant(num_repeats=1)
 

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -297,7 +297,7 @@ def test__check_wiregrid_position_invalid(position):
 def test_time_constant_cw():
     # Setup all mock clients
     wiregrid.run.CLIENTS['acu'] = create_acu_client(180, 50, 0)
-    wiregrid.run.hwp.get_direction = MagicMock(return_value='cw')  # cw
+    wiregrid.run.hwp._get_direction = MagicMock(return_value='cw')  # cw
     wiregrid.run.CLIENTS['wiregrid']['actuator'] = \
         create_actuator_client(motor=1, position='outside')
     wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
@@ -346,7 +346,7 @@ def test_time_constant_cw():
 def test_time_constant_ccw_el90():
     # Setup all mock clients
     wiregrid.run.CLIENTS['acu'] = create_acu_client(180, 90, 0)
-    wiregrid.run.hwp.get_direction = MagicMock(return_value='ccw')  # ccw
+    wiregrid.run.hwp._get_direction = MagicMock(return_value='ccw')  # ccw
     wiregrid.run.CLIENTS['wiregrid']['actuator'] = \
         create_actuator_client(motor=1, position='outside')
     wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
@@ -395,7 +395,7 @@ def test_time_constant_ccw_el90():
 def test_time_constant_repeats():
     # Setup all mock clients
     wiregrid.run.CLIENTS['acu'] = create_acu_client(180, 50, 0)
-    wiregrid.run.hwp.get_direction = MagicMock(return_value='cw')  # cw
+    wiregrid.run.hwp._get_direction = MagicMock(return_value='cw')  # cw
     wiregrid.run.CLIENTS['wiregrid']['actuator'] = \
         create_actuator_client(motor=1, position='outside')
     wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -35,27 +35,6 @@ def create_acu_client(az, el, boresight):
     return acu_client
 
 
-def create_hwp_client(direction):
-    """Create a HWP client with mock acq Process session.data.
-
-    Args:
-        direction (str): direction of the HWP. 'cw' (clockwise) or 'ccw' (counter-clockwise).
-
-    """
-    client = MagicMock()
-    session = create_session('acq')
-    session.data = {
-        'hwp_state': {
-            'direction': direction,
-        },
-        'timestamp': time.time(),
-    }
-    reply = OCSReply(ocs.OK, 'msg', session.encoded())
-    client.monitor.status = MagicMock(return_value=reply)
-
-    return client
-
-
 def create_labjack_client():
     """Create a labjack client with mock acq Process session.data."""
     client = MagicMock()
@@ -359,7 +338,7 @@ def test_time_constant_cw():
         assert client.stream.start.call_args_list == expected_calls_of_streams
         assert client.stream.stop.call_count == 6
 
-    assert wiregrid.run.wiregrid.rotate.call_count == 2
+    assert wiregrid.run.wiregrid.rotate.call_count == 3
 
 
 @patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -349,7 +349,7 @@ def test_time_constant_cw():
         'wiregrid, wg_time_constant, wg_ejecting, hwp_ccw',
     ]
     expected_calls_of_streams = [
-        call(tag=stream_tag, subtype='cal', kwargs=common_kwargs_of_streams)
+        call(subtype='cal', tag=stream_tag, kwargs=common_kwargs_of_streams)
         for stream_tag in expected_tags_of_streams
     ]
 

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -313,26 +313,6 @@ def test__check_wiregrid_position_invalid(position):
     wiregrid.run.CLIENTS['wiregrid']['actuator'].acq.status.assert_called_once()
 
 
-@pytest.mark.parametrize('direction', [('cw'), ('ccw')])
-@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
-def test__check_hwp_direction(direction):
-    wiregrid.run.CLIENTS['hwp'] = create_hwp_client(direction)
-    hwp_direction = wiregrid._check_hwp_direction()
-    if direction == 'cw':
-        assert hwp_direction == 'cw'
-    elif direction == 'ccw':
-        assert hwp_direction == 'ccw'
-    wiregrid.run.CLIENTS['hwp'].monitor.status.assert_called_once()
-
-
-@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
-def test__check_hwp_direction_invalid():
-    wiregrid.run.CLIENTS['hwp'] = create_hwp_client(direction=None)
-    with pytest.raises(RuntimeError):
-        wiregrid._check_hwp_direction()
-    wiregrid.run.CLIENTS['hwp'].monitor.status.assert_called_once()
-
-
 @patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
 @patch('sorunlib.wiregrid.time.sleep', MagicMock())
 def test_time_constant_cw():
@@ -363,8 +343,8 @@ def test_time_constant_cw():
     expected_tags_of_streams = [
         'wiregrid, wg_time_constant, wg_inserting, hwp_cw',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_cw',
-        'wiregrid, wg_time_constant, hwp_change_cw_to_0',
-        'wiregrid, wg_time_constant, hwp_change_0_to_ccw',
+        'wiregrid, wg_time_constant, hwp_change_cw_to_stop',
+        'wiregrid, wg_time_constant, hwp_change_stop_to_ccw',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_ccw',
         'wiregrid, wg_time_constant, wg_ejecting, hwp_ccw',
     ]
@@ -411,8 +391,8 @@ def test_time_constant_ccw_el90():
     expected_tags_of_streams = [
         'wiregrid, wg_time_constant, wg_inserting, hwp_ccw, wg_el90',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_ccw, wg_el90',
-        'wiregrid, wg_time_constant, hwp_change_ccw_to_0, wg_el90',
-        'wiregrid, wg_time_constant, hwp_change_0_to_cw, wg_el90',
+        'wiregrid, wg_time_constant, hwp_change_ccw_to_stop, wg_el90',
+        'wiregrid, wg_time_constant, hwp_change_stop_to_cw, wg_el90',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_cw, wg_el90',
         'wiregrid, wg_time_constant, wg_ejecting, hwp_cw, wg_el90',
     ]
@@ -426,7 +406,7 @@ def test_time_constant_ccw_el90():
         assert client.stream.start.call_args_list == expected_calls_of_streams
         assert client.stream.stop.call_count == 6
 
-    assert wiregrid.run.wiregrid.rotate.call_count == 2
+    assert wiregrid.run.wiregrid.rotate.call_count == 3
 
 
 @patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
@@ -461,11 +441,11 @@ def test_time_constant_repeats():
     expected_tags_of_streams = [
         'wiregrid, wg_time_constant, wg_inserting, hwp_cw',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_cw',
-        'wiregrid, wg_time_constant, hwp_change_cw_to_0',
-        'wiregrid, wg_time_constant, hwp_change_0_to_ccw',
+        'wiregrid, wg_time_constant, hwp_change_cw_to_stop',
+        'wiregrid, wg_time_constant, hwp_change_stop_to_ccw',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_ccw',
-        'wiregrid, wg_time_constant, hwp_change_ccw_to_0',
-        'wiregrid, wg_time_constant, hwp_change_0_to_cw',
+        'wiregrid, wg_time_constant, hwp_change_ccw_to_stop',
+        'wiregrid, wg_time_constant, hwp_change_stop_to_cw',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_cw',
         'wiregrid, wg_time_constant, wg_ejecting, hwp_cw',
     ]
@@ -479,7 +459,7 @@ def test_time_constant_repeats():
         assert client.stream.start.call_args_list == expected_calls_of_streams
         assert client.stream.stop.call_count == 9
 
-    assert wiregrid.run.wiregrid.rotate.call_count == 3
+    assert wiregrid.run.wiregrid.rotate.call_count == 4
 
 
 @patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -45,7 +45,7 @@ def create_hwp_client(pid_direction):
     client = MagicMock()
     session = create_session('acq')
     session.data = {
-        'hwp_status': {
+        'hwp_state': {
             'pid_direction': pid_direction,
         },
         'timestamp': time.time(),
@@ -386,10 +386,10 @@ def test_time_constant_forward():
     # just make sure bias_steps and streams because other functions are already
     # tested separately.
     expected_calls_of_bias_steps = [
-        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_2hz_forward'),
-        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_2hz_forward'),
-        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_2hz_backward'),
-        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_2hz_backward'),
+        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_forward'),
+        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_forward'),
+        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_backward'),
+        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_backward'),
     ]
 
     common_kwargs_of_streams = {
@@ -397,9 +397,9 @@ def test_time_constant_forward():
         "filter_disable": False
     }
     expected_tags_of_streams = [
-        'wiregrid, wg_time_constant, wg_inserting, hwp_2hz_forward',
+        'wiregrid, wg_time_constant, wg_inserting, hwp_forward',
         'wiregrid, wg_time_constant, hwp_change_to_backward',
-        'wiregrid, wg_time_constant, wg_ejecting, hwp_2hz_backward',
+        'wiregrid, wg_time_constant, wg_ejecting, hwp_backward',
     ]
     expected_calls_of_streams = [
         call(tag=stream_tag, subtype='cal', kwargs=common_kwargs_of_streams)
@@ -429,10 +429,10 @@ def test_time_constant_backward_el90():
     # just make sure bias_steps and streams because other functions are already
     # tested separately.
     expected_calls_of_bias_steps = [
-        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_2hz_backward, wg_el90'),
-        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_2hz_backward, wg_el90'),
-        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_2hz_forward, wg_el90'),
-        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_2hz_forward, wg_el90'),
+        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_backward, wg_el90'),
+        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_backward, wg_el90'),
+        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_forward, wg_el90'),
+        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_forward, wg_el90'),
     ]
 
     common_kwargs_of_streams = {
@@ -440,9 +440,9 @@ def test_time_constant_backward_el90():
         "filter_disable": False
     }
     expected_tags_of_streams = [
-        'wiregrid, wg_time_constant, wg_inserting, hwp_2hz_backward, wg_el90',
+        'wiregrid, wg_time_constant, wg_inserting, hwp_backward, wg_el90',
         'wiregrid, wg_time_constant, hwp_change_to_forward, wg_el90',
-        'wiregrid, wg_time_constant, wg_ejecting, hwp_2hz_forward, wg_el90',
+        'wiregrid, wg_time_constant, wg_ejecting, hwp_forward, wg_el90',
     ]
     expected_calls_of_streams = [
         call(tag=stream_tag, subtype='cal', kwargs=common_kwargs_of_streams)
@@ -473,11 +473,11 @@ def test_time_constant_repeats():
     # just make sure bias_steps and streams because other functions are already
     # tested separately.
     expected_calls_of_bias_steps = [
-        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_2hz_forward'),
-        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_2hz_forward'),
-        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_2hz_backward'),
-        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_2hz_forward'),
-        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_2hz_forward'),
+        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_forward'),
+        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_forward'),
+        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_backward'),
+        call(tag='wiregrid, wg_time_constant, wg_inserted, hwp_forward'),
+        call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_forward'),
     ]
 
     common_kwargs_of_streams = {
@@ -485,10 +485,10 @@ def test_time_constant_repeats():
         "filter_disable": False
     }
     expected_tags_of_streams = [
-        'wiregrid, wg_time_constant, wg_inserting, hwp_2hz_forward',
+        'wiregrid, wg_time_constant, wg_inserting, hwp_forward',
         'wiregrid, wg_time_constant, hwp_change_to_backward',
         'wiregrid, wg_time_constant, hwp_change_to_forward',
-        'wiregrid, wg_time_constant, wg_ejecting, hwp_2hz_forward',
+        'wiregrid, wg_time_constant, wg_ejecting, hwp_forward',
     ]
     expected_calls_of_streams = [
         call(tag=stream_tag, subtype='cal', kwargs=common_kwargs_of_streams)

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch, call
 
 import ocs
 from ocs.ocs_client import OCSReply
-from sorunlib import wiregrid
+from sorunlib import wiregrid, hwp
 
 from util import create_session, create_patch_clients, mocked_clients
 
@@ -314,11 +314,12 @@ def test__check_wiregrid_position_invalid(position):
 
 
 @patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+@patch('sorunlib.hwp.run.CLIENTS', mocked_clients())
 @patch('sorunlib.wiregrid.time.sleep', MagicMock())
 def test_time_constant_cw():
     # Setup all mock clients
     wiregrid.run.CLIENTS['acu'] = create_acu_client(180, 50, 0)
-    wiregrid.run.CLIENTS['hwp'] = create_hwp_client('cw')  # cw
+    hwp.run.CLIENTS['hwp'] = create_hwp_client('cw')  # cw
     wiregrid.run.CLIENTS['wiregrid']['actuator'] = \
         create_actuator_client(motor=1, position='outside')
     wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
@@ -349,7 +350,7 @@ def test_time_constant_cw():
         'wiregrid, wg_time_constant, wg_ejecting, hwp_ccw',
     ]
     expected_calls_of_streams = [
-        call(subtype='cal', tag=stream_tag, kwargs=common_kwargs_of_streams)
+        call(tag=stream_tag, subtype='cal', kwargs=common_kwargs_of_streams)
         for stream_tag in expected_tags_of_streams
     ]
 
@@ -410,6 +411,7 @@ def test_time_constant_ccw_el90():
 
 
 @patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+@patch('sorunlib.hwp.run.CLIENTS', mocked_clients())
 @patch('sorunlib.wiregrid.time.sleep', MagicMock())
 def test_time_constant_repeats():
     # Setup all mock clients

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -1,6 +1,7 @@
 import os
 import time
 os.environ["OCS_CONFIG_DIR"] = "./test_util/"
+os.environ["SORUNLIB_CONFIG"] = "./data/example_config.yaml"
 
 import pytest
 
@@ -459,6 +460,24 @@ def test_time_constant_wiregrid_position_failed():
     wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
     wiregrid.run.CLIENTS['wiregrid']['encoder'] = create_encoder_client()
     wiregrid.run.CLIENTS['wiregrid']['labjack'] = create_labjack_client()
+
+    with pytest.raises(RuntimeError):
+        wiregrid.time_constant(num_repeats=1)
+
+
+@patch('sorunlib.wiregrid.run.CLIENTS', mocked_clients())
+@patch('sorunlib.wiregrid.time.sleep', MagicMock())
+def test_time_constant_hwp_direction_failed():
+    wiregrid.run.CLIENTS['acu'] = create_acu_client(180, 50, 0)
+    wiregrid.run.CLIENTS['wiregrid']['actuator'] = \
+        create_actuator_client(motor=1, position='outside')
+    wiregrid.run.CLIENTS['wiregrid']['kikusui'] = create_kikusui_client()
+    wiregrid.run.CLIENTS['wiregrid']['encoder'] = create_encoder_client()
+    wiregrid.run.CLIENTS['wiregrid']['labjack'] = create_labjack_client()
+
+    # Set up expected raise from invalid direction
+    wiregrid.run.hwp._get_direction = MagicMock(return_value=None)
+    wiregrid.run.hwp._get_direction.side_effect = RuntimeError("The HWP direction is unknown. Aborting...")
 
     with pytest.raises(RuntimeError):
         wiregrid.time_constant(num_repeats=1)


### PR DESCRIPTION
I added some APIs for a time constant measurement with the wire grid and the HWP into the `wiregrid.py`. 
Here is the added functions and its explanation:

1. `_check_wiregrid_position()`
    - This function checks the wire grid is off the window or on the window from the logs for the limit switches.
2. `_stop_hwp_with_wiregrid()`
    - This function confirms the wire grid is on the window and stops the HWP.
3. `_spin_hwp_with_wiregrid(target_hwp_direction)`
    - This function confirms the wire grid is on the window and spins up the HWP in the direction same as `target_hwp_direction`.
    - `target_hwp_direction` is bool argument, `'forward'` or `'backward'`.
4. `_reverse_hwp_with_wiregrid(initial_hwp_direction, streaming=False, stepwise_before=False, stepwise_after=False)`
    - This function reverses the HWP spinning direction from `initial_hwp_direction` using `_stop_hwp_with_wiregrid()` and `_spin_hwp_with_wiregrid(target_hwp_direction)`
    - Also, the stepwise rotation can be performed before and/or after the reversing. The bool arguments `stepwise_before` and `stepwise_after` are to identify whether performing them or not.
    - SMuRF streaming can be performed during the stepwise rotation and HWP speed change.
5. `time_constant(initial_hwp_direction, stepwise_first=True, stepwise_last=True, stepwise_mid=False, repeat=1)`
    - This is the main public API. This function inserts the wire grid, changes the HWP direction as many times as `repeat`, and ejects the wire grid.
    - Also, it takes bias steps before and after the insertion and ejection, execute the stepwise rotations before, in the middle of, or after the HWP direction changes.

Any questions and comments are welcome.