### PR TITLE
Implement `acu.move_to_target()` for drifting targets

### DIFF
--- a/src/sorunlib/acu.py
+++ b/src/sorunlib/acu.py
@@ -1,4 +1,8 @@
+import datetime as dt
+
 import sorunlib as run
+
+from sorunlib.commands import _timestamp_to_utc_datetime
 from sorunlib._internal import check_response
 
 
@@ -13,6 +17,35 @@ def move_to(az, el):
     acu = run.CLIENTS['acu']
     resp = acu.go_to(az=az, el=el)
     check_response(acu, resp)
+
+
+def move_to_target(az, el, start_time, stop_time, drift):
+    """Move telescope to a given drifting target.
+
+    Args:
+        az (float): Destination angle for the azimuthal axis.
+        el (float): Destination angle for the elevation axis.
+        start_time (str): Time in ISO format that target is at the given
+            coordinates, i.e. "2024-09-22T07:13:34.416664+00:00".
+        stop_time (str): Time in ISO format that the target is no longer
+            available to scan, i.e. "2024-09-22T08:42:16.343049+00:00".
+        drift (float): Azimuthal drift rate of the target in degrees per
+            second. Used to adjust ``az`` if the move occurs after
+            ``start_time`` but before ``stop_time``.
+
+    """
+    start = _timestamp_to_utc_datetime(start_time)
+    stop = _timestamp_to_utc_datetime(stop_time)
+    now = dt.datetime.now(dt.timezone.utc)
+
+    if now > start and now < stop:
+        az = az + drift * (now - start).total_seconds()
+        print(f"Target has drifted since {start_time}. Moving to ({az}, {el}).")
+
+    if now > stop:
+        return
+
+    move_to(az, el)
 
 
 def set_boresight(target):


### PR DESCRIPTION
One part of #169, this implements `acu.move_to_target()`, which accounts for the drift of a target on the sky if the scan gets started late.

Resolves #137.