### PR TITLE
Upload code coverage to codecov.io

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -52,5 +52,11 @@ jobs:
         mv ./tests/.coverage.* ./
         pip install coveralls
         coverage combine
+        coverage xml
         coverage report
         coveralls --service=github
+
+    - name: Upload results to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Going to migrate services for coverage reporting, testing out configs for codecov.io.