### PR TITLE
Replace coveralls with codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,1 +1,14 @@
+---
+# https://docs.codecov.com/docs/pull-request-comments#disable-comment
 comment: false
+
+# https://docs.codecov.com/docs/commit-status
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1
+        paths:
+          - "src/"
+    patch: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,47 +9,8 @@ on:
       - 'v*.*.*dev*'  # for testing releases
 
 jobs:
-  test:  # Copied from pytest.yml
-    name: pytest with coverage
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.8
-
-    - name: clone sorunlib
-      uses: actions/checkout@v4
-
-    - name: Lint with flake8
-      run: |
-        pip3 install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 ./src/ --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 ./src/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
-    - name: Install sorunlib
-      run: |
-        pip3 install -e .[tests]
-
-    # Unit Tests
-    - name: Run unit tests
-      working-directory: ./tests
-      run: |
-        COVERAGE_FILE=.coverage.unit python3 -m pytest --cov sorunlib
-
-    # Coverage
-    - name: Report test coverage
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        mv ./tests/.coverage.* ./
-        pip install coveralls
-        coverage combine
-        coverage report
-        coveralls --service=github
+  test:
+    uses: ./.github/workflows/pytest.yml
 
   wheel:
     name: build and deploy to PyPI

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,4 +57,3 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        verbose: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,3 +57,4 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,15 +47,11 @@ jobs:
 
     # Coverage
     - name: Report test coverage
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         mv ./tests/.coverage.* ./
-        pip install coveralls
         coverage combine
         coverage xml
         coverage report
-        coveralls --service=github
 
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
 jobs:
   test:

--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,8 @@ This project is licensed under the BSD 2-Clause License - see the
 .. _LICENSE.txt: https://github.com/simonsobs/sorunlib/blob/main/LICENSE.txt
 
 
-.. |coverage| image:: https://coveralls.io/repos/github/simonsobs/sorunlib/badge.svg?branch=main
-    :target: https://coveralls.io/github/simonsobs/sorunlib?branch=main
+.. |coverage| image:: https://codecov.io/github/simonsobs/sorunlib/graph/badge.svg?token=701SYU7A4I
+    :target: https://codecov.io/github/simonsobs/sorunlib
 
 .. |docs| image:: https://readthedocs.org/projects/sorunlib/badge/?version=latest
     :target: https://sorunlib.readthedocs.io/en/latest/?badge=latest


### PR DESCRIPTION
This PR replaces coveralls with codecov. It also implements workflow re-use for the pytest workflow to reduce duplication.