### PR TITLE
Inherit secrets in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/pytest.yml
+    secrets: inherit
 
   wheel:
     name: build and deploy to PyPI


### PR DESCRIPTION
This allows passing secrets needed to upload code coverage when running the pytest workflow from the deploy workflow.