### PR TITLE
Add `start_position` argument to `seq.scan()`

### DIFF
--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -25,6 +25,15 @@ def test_scan(patch_clients):
 
 
 @patch('sorunlib._internal.time.sleep', MagicMock())
+def test_scan_start_position(patch_clients):
+    # This affects test runtime duration keep it short
+    target = dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=0.01)
+    seq.scan(description='test', stop_time=target.isoformat(), width=20.,
+             start_position=(208.5, 60.0))
+    seq.run.CLIENTS['acu'].go_to.assert_called_with(az=208.5, el=60.0)
+
+
+@patch('sorunlib._internal.time.sleep', MagicMock())
 def test_scan_passed_stop_time(patch_clients):
     # This affects test runtime duration keep it short
     target = dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=10)


### PR DESCRIPTION
This PR introduces the `start_position` argument to `seq.scan()`. This optional argument, if passed, will move the telescope to the start position before beginning the scan.

One thing to consider here is the time checking. In each scan we are checking whether the `stop_time` has already passed and whether there is enough time between "now" and `stop_time` for the scan to be at least `min_duration`. In either case we just skip the scan if there isn't enough time.

Now the `stop_time` passed check happens first, then motion to `start_position`, and then we check if there's enough time left. I don't know how tight the scans could possibly be scheduled, but since we previously would already be in the correct position at the start of the scan I could potentially see an impact on whether we pass the `min_duration` check given we'll be taking up some time to move that was maybe previously accounted for in the scheduler. Someone more familiar with the scheduler should comment.

Resolves #190.