### PR TITLE
Handle SMuRF errors when wrapping up scan

### DIFF
--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -9,6 +9,20 @@ from sorunlib._internal import check_response, check_started, monitor_process
 OP_TIMEOUT = 60
 
 
+def _stop_scan():
+    acu = run.CLIENTS['acu']
+
+    print("Stopping scan.")
+    # Stop SMuRF streams
+    run.smurf.stream('off')
+
+    # Stop motion
+    acu.generate_scan.stop()
+    resp = acu.generate_scan.wait(timeout=OP_TIMEOUT)
+    check_response(acu, resp)
+    print("Scan finished.")
+
+
 def scan(description, stop_time, width, az_drift=0, tag=None, subtype=None,
          min_duration=None):
     """Run a constant elevation scan, collecting detector data.
@@ -67,12 +81,4 @@ def scan(description, stop_time, width, az_drift=0, tag=None, subtype=None,
         # Wait until stop time
         monitor_process(acu, 'generate_scan', stop_time)
     finally:
-        print("Stopping scan.")
-        # Stop SMuRF streams
-        run.smurf.stream('off')
-
-        # Stop motion
-        acu.generate_scan.stop()
-        resp = acu.generate_scan.wait(timeout=OP_TIMEOUT)
-        check_response(acu, resp)
-        print("Scan finished.")
+        _stop_scan()

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -14,7 +14,10 @@ def _stop_scan():
 
     print("Stopping scan.")
     # Stop SMuRF streams
-    run.smurf.stream('off')
+    try:
+        run.smurf.stream('off')
+    except RuntimeError as e:
+        print(f"Caught error while shutting down SMuRF streams: {e}")
 
     # Stop motion
     acu.generate_scan.stop()

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -38,7 +38,7 @@ def _check_smurf_threshold():
     remaining = len(run.CLIENTS['smurf'])
     if remaining < threshold:
         error = 'Functional SMuRF count below failure threshold ' + \
-                f'({remaining} < {threshold}). Aborting.'
+                f'({remaining} < {threshold}).'
         raise RuntimeError(error)
 
 


### PR DESCRIPTION
This PR adds some error handling to the scan shutdown block to handle the issue described in #192. In order to make it easier to test, the scan shutdown was separated to a separate function.

Resolves #192.