### PR TITLE
Add fast brake option for hwp.py

### DIFF
--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -20,7 +20,7 @@ def set_freq(freq):
     check_response(hwp, resp)
 
 
-def stop(active=True, brake_voltage=None):
+def stop(active=True, brake_voltage=None, fast=False):
     """Stop the HWP.
 
     Args:
@@ -35,9 +35,9 @@ def stop(active=True, brake_voltage=None):
 
     if active:
         if brake_voltage is None:
-            resp = hwp.brake()
+            resp = hwp.brake(fast=fast)
         else:
-            resp = hwp.brake(brake_voltage=brake_voltage)
+            resp = hwp.brake(brake_voltage=brake_voltage, fast=fast)
         check_response(hwp, resp)
     else:
         resp = hwp.pmx_off()


### PR DESCRIPTION
The fast brake option in this PR is related to #179. 

WG team is trying to measure the time constant by changing the hwp frequency rapidly e.g. +2Hz to -2Hz.
Current brake command is designed for gentle spindown and it takes >10 min to start inverse rotation.
New option of brake command is expected to take <2 min to spindown.
https://docs.google.com/presentation/d/1-kgAFn2sVR3R_Hp8_HcEYgZ8_SoNihm-UwsMn-Skxto/edit?usp=sharing

The modification in `hwp_supervisor` is discussed in [PR #787 in socs](https://github.com/simonsobs/socs/pull/787).
