### PR TITLE
Add missing doublequote in docstring examples

### DIFF
--- a/src/sorunlib/commands.py
+++ b/src/sorunlib/commands.py
@@ -57,7 +57,7 @@ def wait_until(timestamp, tolerance=None):
         >>> wait_until("2015-10-21T07:28:00")
         >>> wait_until("2015-10-21T07:28:00+00:00")
         >>> wait_until("2015-10-21T07:28:00+00:00", 60)
-        >>> wait_until("2015-10-21T07:28:00+00:00", "2015-10-21T07:29:00+00:00)
+        >>> wait_until("2015-10-21T07:28:00+00:00", "2015-10-21T07:29:00+00:00")
 
     """
     target = _timestamp_to_utc_datetime(timestamp)


### PR DESCRIPTION
Just a quick docstring fix I noticed while looking at this code.