### PR TITLE
Add downsample_factor and filter_disable option to smurf.stream

### DIFF
--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -347,7 +347,7 @@ def stream(state, tag=None, subtype=None, downsample_factor=None, filter_disable
         tag (str, optional): Tag or comma-separated listed of tags to attach to
             the operation.
         subtype (str, optional): Operation subtype used to tag the stream.
-        downsample_factor (int, optional): Downsample factor. If None, this will be 
+        downsample_factor (int, optional): Downsample factor. If None, this will be
             pulled from the device cfg.
         filter_disable (bool, optional): If true, will disable the downsample filter
             before streaming.

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -339,7 +339,7 @@ def shutdown(concurrent=True, settling_time=0):
             settling_time=settling_time)
 
 
-def stream(state, tag=None, subtype=None):
+def stream(state, tag=None, subtype=None, downsample_factor=None, filter_disable=False):
     """Stream data on all SMuRF Controllers.
 
     Args:
@@ -347,13 +347,19 @@ def stream(state, tag=None, subtype=None):
         tag (str, optional): Tag or comma-separated listed of tags to attach to
             the operation.
         subtype (str, optional): Operation subtype used to tag the stream.
+        downsample_factor (int, optional): Downsample factor. If None, this will be 
+            pulled from the device cfg.
+        filter_disable (bool, optional): If true, will disable the downsample filter
+            before streaming.
 
     """
     clients_to_remove = []
+    kwargs = {'downsample_factor': downsample_factor,
+              'filter_disable': filter_disable}
 
     if state.lower() == 'on':
         for smurf in run.CLIENTS['smurf']:
-            smurf.stream.start(subtype=subtype, tag=tag)
+            smurf.stream.start(subtype=subtype, tag=tag, kwargs=kwargs)
 
         for smurf in run.CLIENTS['smurf']:
             resp = smurf.stream.status()

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -248,7 +248,13 @@ def test_calibrate_stepwise(patch_clients, continuous, el, tag):
     # All other internal functions tested separately, just make sure smurf
     # stream is run
     for client in wiregrid.run.CLIENTS['smurf']:
-        client.stream.start.assert_called_with(tag=tag, subtype='cal')
+        client.stream.start.assert_called_with(
+            tag=tag,
+            subtype='cal',
+            kwargs={
+                "downsample_factor": None,
+                "filter_disable": False},
+        )
         client.stream.stop.assert_called()
 
 


### PR DESCRIPTION
We are planning to change downsample_factor and filter_disable option of the smurf stream during time-constant calibration using stimulator.
This feature enables changing these parameters from sorunlib functionality.