### PR TITLE
Stimulator codes for sorunlib

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -51,6 +51,14 @@ sorunlib.smurf
     :undoc-members:
     :show-inheritance:
 
+sorunlib.stimulator
+-------------------
+
+.. automodule:: sorunlib.stimulator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 sorunlib.util
 -------------
 

--- a/src/sorunlib/__init__.py
+++ b/src/sorunlib/__init__.py
@@ -1,4 +1,4 @@
-from . import acu, hwp, seq, smurf, wiregrid
+from . import acu, hwp, seq, smurf, stimulator, wiregrid
 
 from .commands import wait_until
 from .util import create_clients
@@ -22,6 +22,7 @@ __all__ = ["acu",
            "hwp",
            "seq",
            "smurf",
+           "stimulator",
            "wiregrid",
            "wait_until",
            "initialize"]

--- a/src/sorunlib/stimulator.py
+++ b/src/sorunlib/stimulator.py
@@ -1,0 +1,126 @@
+import time
+import sorunlib as run
+
+ID_SHUTTER = 1
+
+
+def _open_shutter():
+    """Open the shutter of the stimulator"""
+    ds  = run.CLIENTS['stimulator']['ds378']
+    ds.set_relay(relay_number=ID_SHUTTER, on_off=1)
+    time.sleep(1)
+
+
+def _close_shutter():
+    """Close the shutter of the stimulator"""
+    ds  = run.CLIENTS['stimulator']['ds378']
+    ds.set_relay(relay_number=ID_SHUTTER, on_off=0)
+    time.sleep(1)
+
+
+def _setup():
+    # Open shutter
+    _open_shutter()
+    time.sleep(1)
+
+    # Acceleration / Decceleration configuration
+    blh = run.CLIENTS['stimulator']['blh']
+    blh.set_value(accl_time=10)
+    blh.set_value(decl_time=10)
+
+
+def _stop():
+    blh = run.CLIENTS['stimulator']['blh']
+    
+    # Stop rotation
+    blh.stop_rotation()
+    time.sleep(10)
+
+    # Close shutter
+    _close_shutter()
+
+
+def calibrate_tau(duration_step=10,
+                  speeds_rpm=[225, 495, 945, 1395, 1845, 2205],
+                  forward=True, do_setup=True, stop=True):
+    """Time constant calibration using the stimulator.
+    
+    Parameters
+    ----------
+    duration_step : float, optional
+        Duration of each step of time constant measurement in sec, default to 10 sec.
+    speeds_rpm : list of float, default [225, 495, 945, 1395, 1845, 2205].
+        List of chopper rotation speed in RPM for each step.
+    forward : bool, default True
+        Chopper rotation direction. True for clockwise rotation.
+    do_setup : bool, default True
+        Do initial setup (i.e. open shutter, set acceleration, start rotation) if True.
+    stop : bool, default True
+        Stop the rotation and close the shutter if True.
+    """
+    
+    blh = run.CLIENTS['stimulator']['blh']
+
+    # Replace to the following after the implementation of `downsample_factor` parameter
+    # run.smurf.stream('on', tag=f'stimulator, tau, {speeds_rpm}', subtype='cal',
+    #                  downsample_factor=1, filter_disable=True)
+    run.smurf.stream('on', tag=f'stimulator, tau, {speeds_rpm}', subtype='cal')
+
+    if do_setup:
+        _setup()
+        # Rotation setting
+        blh.set_value(speed=speeds_rpm[0])
+        blh.start_rotation(forward)
+        speeds_rpm = speeds_rpm[1:]
+
+        # First data point
+        time.sleep(duration_step)
+
+    for speed_rpm in speeds_rpm:
+        blh.set_value(speed=speed_rpm)
+        time.sleep(duration_step)
+
+    if stop:
+        _stop()
+
+    run.smurf.stream('off')
+
+
+def calibrate_gain(duration=60, speed_rpm=90,
+                   forward=True, do_setup=True, stop=True):
+    """Gain calibration with the stimulator
+    
+    Parameters
+    ----------
+    duration : float, optional
+        Duration of the gain calibration in sec, default to 60 sec.
+    speed_rpm : float, optional
+        Rotation speed of the chopper wheel in RPM, default to 90 RPM.
+    forward : bool, default True
+        Chopper rotation direction. True for clockwise rotation.
+    do_setup : bool, default True
+        Do initial setup (i.e. open shutter, set acceleration, start rotation) if True.
+    stop : bool, default True
+        Stop the rotation and close the shutter if True.
+    """
+    blh = run.CLIENTS['stimulator']['blh']
+
+    run.smurf.stream('on', tag=f'stimulator, gain, {speed_rpm}', subtype='cal')
+
+    blh.set_value(speed=speed_rpm)
+
+    if do_setup:
+        _setup()
+        # Rotation setting
+        blh.start_rotation(forward)
+
+    # Sleep for rotation stabilization
+    time.sleep(10)
+    
+    # Data taking
+    time.sleep(duration)
+
+    if stop:
+        _stop()
+
+    run.smurf.stream('off')

--- a/src/sorunlib/util.py
+++ b/src/sorunlib/util.py
@@ -154,6 +154,32 @@ def _create_wiregrid_clients(config=None, sorunlib_config=None):
     return clients
 
 
+def _create_stimulator_clients():
+    """Create all stimulator related clients.
+
+    Returns:
+        dict: Dictionary with the keys, 'blh', 'pcr500ma', and 'ds378'
+            with each value being the corresponding OCSClient.
+
+    """
+    blh_id = _find_active_instances('BLHAgent')
+    pcr500ma_id = _find_active_instances('PCR500MAAgent')
+    ds378_id = _find_active_instances('DS378Agent')
+
+    clients = {}
+
+    if blh_id:
+        clients['blh'] = _try_client(blh_id)
+
+    if pcr500ma_id:
+        clients['pcr500ma'] = _try_client(pcr500ma_id)
+
+    if ds378_id:
+        clients['ds378'] = _try_client(ds378_id)
+
+    return clients
+
+
 def create_clients(config=None, sorunlib_config=None, test_mode=False):
     """Create all clients needed for commanding a single platform.
 
@@ -208,5 +234,7 @@ def create_clients(config=None, sorunlib_config=None, test_mode=False):
     clients['wiregrid'] = _create_wiregrid_clients(
         config=config,
         sorunlib_config=sorunlib_config)
+
+    clients['stimulator'] = _create_stimulator_clients()
 
     return clients

--- a/tests/test_stimulator.py
+++ b/tests/test_stimulator.py
@@ -1,0 +1,23 @@
+import os
+os.environ["OCS_CONFIG_DIR"] = "./test_util/"
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from sorunlib import stimulator
+
+from util import create_patch_clients
+
+
+patch_clients_lat = create_patch_clients('lat')
+
+
+@pytest.mark.parametrize("do_setup", [True, False])
+@patch('sorunlib.stimulator.time.sleep', MagicMock())
+def test_calibrate_tau(patch_clients_lat, do_setup):
+    stimulator.calibrate_tau(do_setup=do_setup)
+
+@pytest.mark.parametrize("do_setup", [True, False])
+@patch('sorunlib.stimulator.time.sleep', MagicMock())
+def test_calibrate_gain(patch_clients_lat, do_setup):
+    stimulator.calibrate_gain(do_setup=do_setup)

--- a/tests/util.py
+++ b/tests/util.py
@@ -82,7 +82,10 @@ def mocked_clients(**kwargs):
                'wiregrid': {'actuator': MagicMock(),
                             'encoder': MagicMock(),
                             'kikusui': MagicMock(),
-                            'labjack': MagicMock()}}
+                            'labjack': MagicMock()},
+               'stimulator': {'blh': MagicMock(),
+                              'ds378': MagicMock(),
+                              'pcr500ma': MagicMock()}}
 
     return clients
 


### PR DESCRIPTION
I added a functionality to handle stimulator from sorunlib.

The stimulator is planned to use for the gain calibration and the timeconstant calibration.
According to these purposes, I made functions `calibrate_gain` and `calibrate_tau` in the main code.
Since the timeconstant calibration requires fast sampling rate, we need the feature I requested in https://github.com/simonsobs/sorunlib/pull/197 .
I put a comment where the `smurf.stream` function should be replaced for fast sampling in the code.