### PR TITLE
hwp: non-active stop will wait until hwp stops

### DIFF
--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -40,5 +40,5 @@ def stop(active=True, brake_voltage=None):
             resp = hwp.brake(brake_voltage=brake_voltage)
         check_response(hwp, resp)
     else:
-        resp = hwp.pmx_off()
+        resp = hwp.pmx_off(wait_stop=True)
         check_response(hwp, resp)

--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -25,14 +25,15 @@ def stop(active=True, brake_voltage=None):
 
     Args:
         active (bool, optional): If True, actively try to stop the HWP by
-            applying the brake. If False, simply turn off the PMX power and let
-            it spin down on its own. Defaults to True.
+            applying the brake. If False, simply turn off the PMX power and wait
+            for it to spin down on its own. Defaults to True.
         brake_voltage (float, optional): Voltage used when actively stopping
             the HWP. Only considered when active is True.
 
     """
     hwp = run.CLIENTS['hwp']
 
+    print('Stop HWP and wait for it to spin down...')
     if active:
         if brake_voltage is None:
             resp = hwp.brake()

--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -33,7 +33,7 @@ def stop(active=True, brake_voltage=None):
     """
     hwp = run.CLIENTS['hwp']
 
-    print('Stop HWP and wait for it to spin down...')
+    print('Stopping HWP and waiting for it to spin down.')
     if active:
         if brake_voltage is None:
             resp = hwp.brake()


### PR DESCRIPTION
I would like to change non-active stop to wait until hwp stops https://github.com/simonsobs/socs/pull/837

We have been adding sleep in schedule before but after this update will just need `run.hwp.stop(active=False)`.
The agents are already updated in all SATs.
```
run.hwp.stop(active=False)
time.sleep(15*60)
```