### PR TITLE
Pass additional kwargs through to SMuRF stream process

### DIFF
--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -346,7 +346,7 @@ def shutdown(concurrent=True, settling_time=0):
             settling_time=settling_time)
 
 
-def stream(state, tag=None, subtype=None, downsample_factor=None, filter_disable=False):
+def stream(state, tag=None, subtype=None, **kwargs):
     """Stream data on all SMuRF Controllers.
 
     Args:
@@ -354,15 +354,12 @@ def stream(state, tag=None, subtype=None, downsample_factor=None, filter_disable
         tag (str, optional): Tag or comma-separated listed of tags to attach to
             the operation.
         subtype (str, optional): Operation subtype used to tag the stream.
-        downsample_factor (int, optional): Downsample factor. If None, this will be
-            pulled from the device cfg.
-        filter_disable (bool, optional): If true, will disable the downsample filter
-            before streaming.
+        **kwargs: Additional keyword arguments. Passed through to the SMuRF
+            controller unmodified. See the `controller documentation
+            <https://socs.readthedocs.io/en/main/agents/pysmurf-controller.html#socs.agents.pysmurf_controller.agent.PysmurfController.stream>`_.
 
     """
     clients_to_remove = []
-    kwargs = {'downsample_factor': downsample_factor,
-              'filter_disable': filter_disable}
 
     if state.lower() == 'on':
         for smurf in run.CLIENTS['smurf']:

--- a/tests/test_smurf.py
+++ b/tests/test_smurf.py
@@ -171,6 +171,20 @@ def test_stream(state):
 
 
 @pytest.mark.parametrize("state", [("on"), ("off")])
+def test_stream_w_kwargs(state):
+    smurf.stream(state=state, tag='test', subtype='test',
+                 downsample_factor=20, filter_disable=False)
+    for client in smurf.run.CLIENTS['smurf']:
+        if state == "on":
+            client.stream.start.assert_called_once_with(tag='test',
+                                                        subtype='test',
+                                                        kwargs={'downsample_factor': 20,
+                                                                'filter_disable': False})
+        else:
+            client.stream.stop.assert_called_once()
+
+
+@pytest.mark.parametrize("state", [("on"), ("off")])
 def test_stream_single_failure(state):
     # Create failure on smurf1
     mocked_response = OCSReply(

--- a/tests/test_wiregrid.py
+++ b/tests/test_wiregrid.py
@@ -262,9 +262,7 @@ def test_calibrate_stepwise(patch_clients, continuous, el, tag):
         client.stream.start.assert_called_with(
             tag=tag,
             subtype='cal',
-            kwargs={
-                "downsample_factor": None,
-                "filter_disable": False},
+            kwargs={},
         )
         client.stream.stop.assert_called()
 
@@ -317,10 +315,6 @@ def test_time_constant_cw():
         call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_ccw')
     ]
 
-    common_kwargs_of_streams = {
-        "downsample_factor": None,
-        "filter_disable": False
-    }
     expected_tags_of_streams = [
         'wiregrid, wg_time_constant, wg_inserting, hwp_cw',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_cw',
@@ -330,7 +324,7 @@ def test_time_constant_cw():
         'wiregrid, wg_time_constant, wg_ejecting, hwp_ccw'
     ]
     expected_calls_of_streams = [
-        call(tag=stream_tag, subtype='cal', kwargs=common_kwargs_of_streams)
+        call(tag=stream_tag, subtype='cal', kwargs={})
         for stream_tag in expected_tags_of_streams
     ]
 
@@ -366,10 +360,6 @@ def test_time_constant_ccw_el90():
         call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_cw, wg_el90')
     ]
 
-    common_kwargs_of_streams = {
-        "downsample_factor": None,
-        "filter_disable": False
-    }
     expected_tags_of_streams = [
         'wiregrid, wg_time_constant, wg_inserting, hwp_ccw, wg_el90',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_ccw, wg_el90',
@@ -379,7 +369,7 @@ def test_time_constant_ccw_el90():
         'wiregrid, wg_time_constant, wg_ejecting, hwp_cw, wg_el90'
     ]
     expected_calls_of_streams = [
-        call(tag=stream_tag, subtype='cal', kwargs=common_kwargs_of_streams)
+        call(tag=stream_tag, subtype='cal', kwargs={})
         for stream_tag in expected_tags_of_streams
     ]
 
@@ -416,10 +406,6 @@ def test_time_constant_repeats():
         call(tag='wiregrid, wg_time_constant, wg_ejected, hwp_cw')
     ]
 
-    common_kwargs_of_streams = {
-        "downsample_factor": None,
-        "filter_disable": False
-    }
     expected_tags_of_streams = [
         'wiregrid, wg_time_constant, wg_inserting, hwp_cw',
         'wiregrid, wg_time_constant, wg_stepwise, hwp_cw',
@@ -432,7 +418,7 @@ def test_time_constant_repeats():
         'wiregrid, wg_time_constant, wg_ejecting, hwp_cw'
     ]
     expected_calls_of_streams = [
-        call(tag=stream_tag, subtype='cal', kwargs=common_kwargs_of_streams)
+        call(tag=stream_tag, subtype='cal', kwargs={})
         for stream_tag in expected_tags_of_streams
     ]
 


### PR DESCRIPTION
This allows arbitrary use of any kwargs in [sodetlib's stream_g3_on function](https://github.com/simonsobs/sodetlib/blob/16ac2732940816b00c9a0d87cd3f407edb96d16f/sodetlib/stream.py#L131C5-L131C17), which the [pysmurf-controller passes through to](https://socs.readthedocs.io/en/main/agents/pysmurf-controller.html#socs.agents.pysmurf_controller.agent.PysmurfController.stream). This includes the arguments removed here as well as new ones like 'filter_order' and 'filter_cutoff'.