### PR TITLE
Add HWP spin up/down commands

### DIFF
--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -47,6 +47,52 @@ def set_freq(freq):
     check_response(hwp, resp)
 
 
+def spin_up(freq):
+    """Spin up the HWP while streaming data.
+
+    Args:
+        freq (float): Target frequency to rotate the HWP in Hz. This is a
+            *signed float*, the meaning of which depends on the OCS site
+            configuration. For details see the `documentation for the HWP
+            Supervisor Agent <docs_>`_.
+
+    .. _docs: https://socs.readthedocs.io/en/main/agents/hwp_supervisor_agent.html
+
+    """
+    hwp = run.CLIENTS['hwp']
+
+    try:
+        run.smurf.stream('on', subtype='cal', tag='hwp_spin_up')
+        resp = hwp.enable_driver_board()
+        check_response(hwp, resp)
+        run.hwp.set_freq(freq=freq)
+    finally:
+        run.smurf.stream('off')
+
+
+def spin_down(active=True, brake_voltage=None):
+    """Spin down the HWP while streaming data.
+
+    Args:
+        active (bool, optional): If True, actively try to stop the HWP by
+            applying the brake. If False, simply turn off the PMX power and wait
+            for it to spin down on its own. Defaults to True.
+        brake_voltage (float, optional): Voltage used when actively stopping
+            the HWP. Only considered when active is True.
+
+    """
+    hwp = run.CLIENTS['hwp']
+
+    try:
+        run.smurf.stream('on', subtype='cal', tag='hwp_spin_down')
+        run.hwp.stop(active=active,
+                     brake_voltage=brake_voltage)
+        resp = hwp.disable_driver_board()
+        check_response(hwp, resp)
+    finally:
+        run.smurf.stream('off')
+
+
 def stop(active=True, brake_voltage=None):
     """Stop the HWP.
 

--- a/tests/test_hwp.py
+++ b/tests/test_hwp.py
@@ -82,7 +82,7 @@ def test_spin_up(patch_clients_satp):
     for client in smurf.run.CLIENTS['smurf']:
         client.stream.start.assert_called_once()
     hwp.run.CLIENTS['hwp'].enable_driver_board.assert_called_once()
-    hwp.run.CLIENTS['hwp'].pid_to_freq.assert_called_with(target_freq=2.0)
+    hwp.run.CLIENTS['hwp'].pid_to_freq.start.assert_called_with(target_freq=2.0)
     for client in smurf.run.CLIENTS['smurf']:
         client.stream.stop.assert_called_once()
 


### PR DESCRIPTION
This PR adds new commands for HWP spin up/down that ensure the driver board is enabled/disabled, and turn on the SMuRF streams during the operation. It also includes a 30 minute timeout on spin up, in the event something goes wrong and the operation hangs.

Example usage:
```python
import sorunlib as run
run.initialize()
run.hwp.spin_up(freq=2.0)
run.hwp.spin_down()
```

Resolves #206.