### PR TITLE
Set up Python version test matrix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,10 @@ jobs:
       TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
 
     steps:
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.10
 
     - name: clone sorunlib
       uses: actions/checkout@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,12 +17,15 @@ jobs:
   test:
     name: pytest with coverage
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
 
     steps:
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python }}
 
     - name: clone sorunlib
       uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the Python version we build and publish with from 3.8 to 3.10. It also sets up a matrix strategy to run tests for 3.10, 3.11, and 3.12.

We currently run exclusively on 3.10, but will eventually update to 3.12 when the `nextline-graphql` docker image upgrades to Ubuntu 24.04.