### PR TITLE
Remove potentially unclear error message

### DIFF
--- a/src/sorunlib/_internal.py
+++ b/src/sorunlib/_internal.py
@@ -116,15 +116,14 @@ def check_started(client, response, timeout=60):
         # Wait at most ~timeout seconds while checking the status
         for i in range(timeout):
             response = _operation.status()
+            _check_error(client, response)
             op_code = response.session.get('op_code')
-            if op_code == 3:
+            if op_code == 3:  # RUNNING
                 # Tricky to change state during testing w/little reward
                 return  # pragma: no cover
             time.sleep(1)
 
-        error = f"Check timed out. Operation {op} in Agent {instance} stuck in " + \
-            "'starting' state.\n" + str(response)
-        raise RuntimeError(error)
+        print("The operation is in an unexpected state after {timeout} seconds.")
 
     if op_code != 3:  # RUNNING
         error = f"Operation {op} in Agent {instance} is not 'running'.\n" + \


### PR DESCRIPTION
This should remove the potentially unclear message pointed out in #164. If we hit the timeout we just print a message about it, then move to the error raised if 'running' wasn't the found state:
https://github.com/simonsobs/sorunlib/blob/d5760b8df8dc87cf30e151b9cc5cdba0dcb39ba1/src/sorunlib/_internal.py#L129-L132

@mhasself, does this clear things up?

Resolves #164.