### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -32,7 +31,7 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Astronomy",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
         'ocs==0.11.3',
         'pyyaml',


### PR DESCRIPTION
Just doing some packaging clean up. We could probably drop 3.9 early too, since this gets run only in a very specific environment.