### PR TITLE
smurf: Block until stream starts

### DIFF
--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -392,7 +392,7 @@ def stream(state, tag=None, subtype=None, wait_for_stream=True, **kwargs):
             try:
                 check_started(smurf, resp, timeout=60)
                 if wait_for_stream:
-                    _wait_for_stream_start(smurf, timeout=60)
+                    _wait_for_stream_start(smurf, timeout=120)
             except RuntimeError as e:
                 print(f"Failed to start stream on {smurf}, removing from targets list.")
                 print(e)

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -390,7 +390,7 @@ def stream(state, tag=None, subtype=None, wait_for_stream=True, **kwargs):
         for smurf in run.CLIENTS['smurf']:
             resp = smurf.stream.status()
             try:
-                check_started(smurf, resp, timeout=120)
+                check_started(smurf, resp, timeout=60)
                 if wait_for_stream:
                     _wait_for_stream_start(smurf, timeout=60)
             except RuntimeError as e:

--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -365,7 +365,7 @@ def _wait_for_stream_start(smurf, timeout):
     raise RuntimeError(f"Stream for {smurf} did not turn on within {timeout} seconds.")
 
 
-def stream(state, tag=None, subtype=None, **kwargs):
+def stream(state, tag=None, subtype=None, wait_for_stream=True, **kwargs):
     """Stream data on all SMuRF Controllers.
 
     Args:
@@ -373,6 +373,9 @@ def stream(state, tag=None, subtype=None, **kwargs):
         tag (str, optional): Tag or comma-separated listed of tags to attach to
             the operation.
         subtype (str, optional): Operation subtype used to tag the stream.
+        wait_for_stream (bool, optional): If True, block until the streams are
+            all enabled. If False, check that the client call goes through, but
+            do not wait. Defaults to True.
         **kwargs: Additional keyword arguments. Passed through to the SMuRF
             controller unmodified. See the `controller documentation
             <https://socs.readthedocs.io/en/main/agents/pysmurf-controller.html#socs.agents.pysmurf_controller.agent.PysmurfController.stream>`_.
@@ -388,7 +391,8 @@ def stream(state, tag=None, subtype=None, **kwargs):
             resp = smurf.stream.status()
             try:
                 check_started(smurf, resp, timeout=120)
-                _wait_for_stream_start(smurf, timeout=60)
+                if wait_for_stream:
+                    _wait_for_stream_start(smurf, timeout=60)
             except RuntimeError as e:
                 print(f"Failed to start stream on {smurf}, removing from targets list.")
                 print(e)

--- a/tests/util.py
+++ b/tests/util.py
@@ -43,6 +43,7 @@ def _mock_smurf_client(instance_id):
 
     # smurf.stream
     session = create_session('stream', status='running')
+    session.data = {'stream_on': True}  # Always assume stream turns on
     reply = OCSReply(ocs.OK, 'msg', session.encoded())
     smurf.stream.start = MagicMock(return_value=reply)
     smurf.stream.status = MagicMock(return_value=reply)


### PR DESCRIPTION
As noted in the commit message for 81d89a312a7fd333afbfc1a1319c61f73ed9ed95, this actually used to block until stream start. When we changed the behavior of ocs to automatically set `session.status('running')` this no longer blocked. Until then, the agent was setting 'running' after the stream was enabled.

We need to merge https://github.com/simonsobs/socs/pull/898, but this at least gets an example for the usage up.

Feedback welcome.

Resolves #215.