### PR TITLE
Fix deploy workflow setup-python step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: '3.10'
 
     - name: clone sorunlib
       uses: actions/checkout@v4


### PR DESCRIPTION
Deployment failed with:
```
Version 3.1 was not found in the local cache
Error: The version '3.1' with architecture 'x64' was not found for Ubuntu 24.04.
```