### PR TITLE
smurf: Assume stream is on if there is no status

### DIFF
--- a/src/sorunlib/smurf.py
+++ b/src/sorunlib/smurf.py
@@ -357,7 +357,7 @@ def _wait_for_stream_start(smurf, timeout):
     """
     for i in range(int(timeout)):
         resp = smurf.stream.status()
-        stream_on = resp.session['data']['stream_on']
+        stream_on = resp.session['data'].get('stream_on', True)
         if stream_on:
             return
         time.sleep(1)


### PR DESCRIPTION
This will otherwise cause issues if a pysmurf-controller hasn't been updated to include the new 'stream_on' key.

This occurred to me as I prepared to deploy the latest release with changes from #218...