### PR TITLE
Add signal handling during shutdown operations

### DIFF
--- a/src/sorunlib/__init__.py
+++ b/src/sorunlib/__init__.py
@@ -1,3 +1,5 @@
+import signal
+
 from . import acu, hwp, seq, smurf, stimulator, wiregrid
 
 from .commands import wait_until
@@ -26,6 +28,15 @@ __all__ = ["acu",
            "wiregrid",
            "wait_until",
            "initialize"]
+
+
+# Treat SIGTERM like SIGINT and raise an exception
+def term_handler(sig, frame):
+    raise KeyboardInterrupt
+
+
+signal.signal(signal.SIGTERM, term_handler)
+
 
 # Define the variable '__version__':
 # This has the closest behavior to versioneer that I could find

--- a/src/sorunlib/_internal.py
+++ b/src/sorunlib/_internal.py
@@ -8,6 +8,7 @@ import datetime as dt
 import time
 
 import ocs
+import sorunlib as run
 
 from sorunlib.commands import _timestamp_to_utc_datetime
 
@@ -180,3 +181,14 @@ def monitor_process(client, operation, stop_time, check_interval=10):
 
         # Recompute diff
         diff = _seconds_until_target(stop_time)
+
+
+def stop_smurfs():
+    """Simple wrapper to shutdown all SMuRF systems and handle any errors that
+    occur.
+
+    """
+    try:
+        run.smurf.stream('off')
+    except RuntimeError as e:
+        print(f"Caught error while shutting down SMuRF streams: {e}")

--- a/src/sorunlib/_internal.py
+++ b/src/sorunlib/_internal.py
@@ -5,7 +5,10 @@ The usual caveats apply, these interfaces might change without notice.
 """
 
 import datetime as dt
+import signal
 import time
+
+from functools import wraps
 
 import ocs
 import sorunlib as run
@@ -183,6 +186,31 @@ def monitor_process(client, operation, stop_time, check_interval=10):
         diff = _seconds_until_target(stop_time)
 
 
+def protect_shutdown(f):
+    """Decorator to install temporary signal handlers while operations required
+    to safely shutdown are handled.
+
+    This will catch and print the caught signals to ``stdout`` while shutdown
+    is happening. Currently handles only ``SIGINT`` and ``SIGTERM``.
+
+    """
+    @wraps(f)
+    def wrapper(*args, **kwds):
+        def handler(sig, frame):
+            print(f'Caught {signal.Signals(sig).name} during shutdown.')
+
+        int_handler = signal.signal(signal.SIGINT, handler)
+        term_handler = signal.signal(signal.SIGTERM, handler)
+
+        result = f(*args, **kwds)
+
+        signal.signal(signal.SIGINT, int_handler)
+        signal.signal(signal.SIGTERM, term_handler)
+        return result
+    return wrapper
+
+
+@protect_shutdown
 def stop_smurfs():
     """Simple wrapper to shutdown all SMuRF systems and handle any errors that
     occur.

--- a/src/sorunlib/hwp.py
+++ b/src/sorunlib/hwp.py
@@ -1,5 +1,5 @@
 import sorunlib as run
-from sorunlib._internal import check_response
+from sorunlib._internal import check_response, stop_smurfs
 
 
 def _get_direction():
@@ -74,7 +74,7 @@ def spin_up(freq):
         check_response(hwp, resp)
         run.hwp.set_freq(freq=freq, timeout=1800)
     finally:
-        run.smurf.stream('off')
+        stop_smurfs()
 
 
 def spin_down(active=True, brake_voltage=None):
@@ -97,7 +97,7 @@ def spin_down(active=True, brake_voltage=None):
         resp = hwp.disable_driver_board()
         check_response(hwp, resp)
     finally:
-        run.smurf.stream('off')
+        stop_smurfs()
 
 
 def stop(active=True, brake_voltage=None):

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -4,25 +4,17 @@ import time
 import sorunlib as run
 
 from sorunlib.commands import _timestamp_to_utc_datetime
-from sorunlib._internal import check_response, check_started, monitor_process
+from sorunlib._internal import check_response, check_started, monitor_process, stop_smurfs
 
 
 OP_TIMEOUT = 60
-
-
-def _stop_smurfs():
-    # Stop SMuRF streams
-    try:
-        run.smurf.stream('off')
-    except RuntimeError as e:
-        print(f"Caught error while shutting down SMuRF streams: {e}")
 
 
 def _stop_scan():
     acu = run.CLIENTS['acu']
 
     print("Stopping scan.")
-    _stop_smurfs()
+    stop_smurfs()
 
     # Stop motion
     acu.generate_scan.stop()
@@ -130,4 +122,4 @@ def el_nod(el1, el2, num=5, pause=5):
             # Return to initial position
             run.acu.move_to(az=init_az, el=init_el)
     finally:
-        _stop_smurfs()
+        stop_smurfs()

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -66,10 +66,10 @@ def scan(description, stop_time, width, az_drift=0, tag=None, subtype=None,
 
     acu = run.CLIENTS['acu']
 
-    # Enable SMuRF streams
-    run.smurf.stream('on', subtype=subtype, tag=tag)
-
     try:
+        # Enable SMuRF streams
+        run.smurf.stream('on', subtype=subtype, tag=tag)
+
         # Grab current telescope position
         resp = acu.monitor.status()
         az = resp.session['data']['StatusDetailed']['Azimuth current position']
@@ -110,10 +110,10 @@ def el_nod(el1, el2, num=5, pause=5):
     """
     acu = run.CLIENTS['acu']
 
-    # Enable SMuRF streams
-    run.smurf.stream('on', subtype='cal', tag='el_nods')
-
     try:
+        # Enable SMuRF streams
+        run.smurf.stream('on', subtype='cal', tag='el_nods')
+
         # Grab current telescope position
         resp = acu.monitor.status()
         init_az = resp.session['data']['StatusDetailed']['Azimuth current position']

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -4,12 +4,13 @@ import time
 import sorunlib as run
 
 from sorunlib.commands import _timestamp_to_utc_datetime
-from sorunlib._internal import check_response, check_started, monitor_process, stop_smurfs
+from sorunlib._internal import check_response, check_started, monitor_process, protect_shutdown, stop_smurfs
 
 
 OP_TIMEOUT = 60
 
 
+@protect_shutdown
 def _stop_scan():
     acu = run.CLIENTS['acu']
 

--- a/src/sorunlib/seq.py
+++ b/src/sorunlib/seq.py
@@ -26,6 +26,7 @@ def _stop_scan():
 
     # Stop motion
     acu.generate_scan.stop()
+    print("Waiting for telescope motion to stop.")
     resp = acu.generate_scan.wait(timeout=OP_TIMEOUT)
     check_response(acu, resp)
     print("Scan finished.")

--- a/src/sorunlib/stimulator.py
+++ b/src/sorunlib/stimulator.py
@@ -1,6 +1,6 @@
 import time
 import sorunlib as run
-from sorunlib._internal import check_response
+from sorunlib._internal import check_response, stop_smurfs
 
 ID_SHUTTER = 1
 
@@ -99,10 +99,7 @@ def calibrate_tau(duration_step=10,
 
             time.sleep(duration_step)
     finally:
-        try:
-            run.smurf.stream('off')
-        except RuntimeError as e:
-            print(f"Caught error while shutting down SMuRF streams: {e}")
+        stop_smurfs()
 
         if stop:
             _stop()
@@ -147,10 +144,7 @@ def calibrate_gain(duration=60, speed_rpm=90,
         # Data taking
         time.sleep(duration)
     finally:
-        try:
-            run.smurf.stream('off')
-        except RuntimeError as e:
-            print(f"Caught error while shutting down SMuRF streams: {e}")
+        stop_smurfs()
 
         if stop:
             _stop()

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -1,7 +1,7 @@
 import time
 
 import sorunlib as run
-from sorunlib._internal import check_response, check_running
+from sorunlib._internal import check_response, check_running, stop_smurfs
 
 EL_DIFF_THRESHOLD = 0.5  # deg diff from target that its ok to run calibration
 BORESIGHT_DIFF_THRESHOLD = 0.5  # deg
@@ -322,7 +322,7 @@ def calibrate(continuous=False, elevation_check=True, boresight_check=True,
         eject()
     finally:
         # Stop SMuRF streams
-        run.smurf.stream('off')
+        stop_smurfs()
 
 
 def time_constant(num_repeats=1):
@@ -381,7 +381,7 @@ def time_constant(num_repeats=1):
         insert()
         time.sleep(5)
     finally:
-        run.smurf.stream('off')
+        stop_smurfs()
 
     for i in range(num_repeats):
         if current_hwp_direction == 'ccw':
@@ -404,7 +404,7 @@ def time_constant(num_repeats=1):
             # Run stepwise rotation
             rotate(continuous=False)
         finally:
-            run.smurf.stream('off')
+            stop_smurfs()
 
         # Stop the HWP while streaming
         try:
@@ -413,7 +413,7 @@ def time_constant(num_repeats=1):
             run.smurf.stream('on', tag=stream_tag, subtype='cal')
             run.hwp.stop(active=True)
         finally:
-            run.smurf.stream('off')
+            stop_smurfs()
 
         # Reverse the HWP while streaming
         try:
@@ -430,7 +430,7 @@ def time_constant(num_repeats=1):
                 run.hwp.set_freq(freq=-2.0)
             current_hwp_direction = target_hwp_direction
         finally:
-            run.smurf.stream('off')
+            stop_smurfs()
 
     # Run stepwise rotation after changing the HWP rotation
     try:
@@ -441,7 +441,7 @@ def time_constant(num_repeats=1):
         # Run stepwise rotation
         rotate(continuous=False)
     finally:
-        run.smurf.stream('off')
+        stop_smurfs()
 
     # Bias step (the wire grid is on the window)
     # After changing the HWP rotation
@@ -458,7 +458,7 @@ def time_constant(num_repeats=1):
         eject()
         time.sleep(5)
     finally:
-        run.smurf.stream('off')
+        stop_smurfs()
 
     # Bias step (the wire grid is off the window)
     bs_tag = 'wiregrid, wg_time_constant, wg_ejected, ' + \


### PR DESCRIPTION
This PR implements signal handling during shutdown operations. This should mitigate issues with commands run from `sorunlib` that error out and leave either SMuRF streaming or ACU motion (or both) on.

Some things I want to mention:
* `SIGTERM` is now always handled just like `SIGINT`. This makes "Interrupt" and "Terminate" behave the same from nextline, both raising a `KeyboardInterrupt`. In my opinion, both signals should result in a clean shutdown. This was the simplest way to accomplish that. I may change how `SIGTERM` is handled in the future to try to shutdown things on its own (likely after #231 or similar gets implemented), and then `sys.exit(0)`, but this should work for now.
* I replaced any direct use of `run.smurf.stream('off')` in modules that called it. This was done so that these modules also benefit from the signal handling addition.
* The `protect_shutdown` decorator should be used on any functions that perform shutdown actions moving forward. This catches the signals and just prints them to stdout while shutdown occurs. If something isn't stopping properly a `SIGKILL` can still be sent to exit (likely with streams/ACU motion still occurring).

I tested this in a local environment with the following elements:
* nextline
* ocs-web
* ACU agent w/accompanying ACU simulator
* 2x SMuRF File Emulator agents

I tested sending `SIGINT`, `SIGTERM`, and `SIGKILL` at various points during an example scan block that looked like this:
```Python
from nextline import disable_trace
import time

with disable_trace():
    import sorunlib as run
    from ocs.ocs_client import OCSClient
    run.initialize(test_mode=True)

run.acu.set_scan_params(0.5, 0.25)
run.acu.move_to(az=49.1, el=60.0)

################### Detector Setup######################
with disable_trace():
    run.initialize(test_mode=True)
run.smurf.take_bgmap(concurrent=True)
run.smurf.take_noise(concurrent=True, tag='res_check')
run.smurf.iv_curve(concurrent=True,
    iv_kwargs={'run_serially': False, 'cool_wait': 60*5})
run.smurf.bias_dets(concurrent=True)
time.sleep(1)
run.smurf.bias_step(concurrent=True)
run.smurf.take_noise(concurrent=True, tag='bias_check')
#################### Detector Setup Over ####################

# hwp already spinning cw (negative frequency)
run.wait_until('2025-09-04T18:27:00+00:00')
run.acu.set_scan_params(0.8, 0.25)
# scan duration = 0:46:30
run.seq.scan(
    description='Medium priority NE scan',
    stop_time='2025-09-09T23:13:30+00:00',
    width=40.0, az_drift=0,
    subtype='cmb', tag='uid-dad4ce63-cd6e-4591-b8b4-a8e747a242dd-pass-0,49-89',
    min_duration=600,
)
run.acu.move_to(az=49.1, el=60.0)
```

I am able to interrupt during the `run.seq.scan()` line and watch the scan stop gracefully. Additional signals sent (with the exception of `SIGKILL`) are simply printed to `stdout`. `SIGKILL` ends things abruptly with streams still running.

This *does not* handle the case of streams left running while a schedule is started. That will still run into the issues described in #229.

Resolves #166.