### PR TITLE
stimulator: Protect stop function from interrupt

### DIFF
--- a/src/sorunlib/stimulator.py
+++ b/src/sorunlib/stimulator.py
@@ -1,6 +1,6 @@
 import time
 import sorunlib as run
-from sorunlib._internal import check_response, stop_smurfs
+from sorunlib._internal import check_response, protect_shutdown, stop_smurfs
 
 ID_SHUTTER = 1
 
@@ -33,6 +33,7 @@ def _setup():
     check_response(blh, resp)
 
 
+@protect_shutdown
 def _stop():
     blh = run.CLIENTS['stimulator']['blh']
 


### PR DESCRIPTION
Similar to #166, a well timed interrupt could leave the shutter open. This protects the `_stop()` function from being interrupted via `SIGINT` or `SIGTERM`.