### PR TITLE
Remove deprecated dependabot reviewers config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BrianJKoopman

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "BrianJKoopman"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "BrianJKoopman"


### PR DESCRIPTION
Replaced with the CODEOWNERS file, as recommended in [1].

[1] - https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/