### PR TITLE
wiregrid: Add wiregrid rotation motor voltage to config file

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -22,6 +22,8 @@ A full configuration file example with comments is shown here:
     # minimum number of SMuRFs that must be working to continue operations
     smurf_failure_threshold: 3
 
+    # voltage in V to apply to the wiregrid motor during rotation
+    wiregrid_motor_voltage: 12.0
     # current in Amps to apply to the wiregrid motor during rotation
     wiregrid_motor_current: 3.0
 

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -113,7 +113,7 @@ def _configure_power(continuous):
     cfg = run.config.load_config()
     voltage = cfg.get('wiregrid_motor_voltage', 12.0)
     current = cfg.get('wiregrid_motor_current', 3.0)
-    
+
     resp = kikusui.set_v(volt=voltage)
     check_response(kikusui, resp)
 

--- a/src/sorunlib/wiregrid.py
+++ b/src/sorunlib/wiregrid.py
@@ -110,11 +110,12 @@ def _configure_power(continuous):
     """
     kikusui = run.CLIENTS['wiregrid']['kikusui']
 
-    resp = kikusui.set_v(volt=12)
-    check_response(kikusui, resp)
-
     cfg = run.config.load_config()
+    voltage = cfg.get('wiregrid_motor_voltage', 12.0)
     current = cfg.get('wiregrid_motor_current', 3.0)
+    
+    resp = kikusui.set_v(volt=voltage)
+    check_response(kikusui, resp)
 
     resp = kikusui.set_c(current=current)
     check_response(kikusui, resp)


### PR DESCRIPTION
I want to change the voltage setting to rotate the wiregrid for SATp2 for a smoother rotation.
So, I added the voltage setting in `wiregrid.py`.

@BrianJKoopman, could you check the change?